### PR TITLE
Add polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [1.0.5] - 2020-10-11
+### Added
+- Platform `PLC`: Polling mode that enables background task poll accessories. New configuration `enablePolling`
+- Accessory: `PLC_WindowCovering`: Adaptive polling when moving blinds. New configuration `adaptivePolling` and `pollInterval`
+- Accessory: `PLC_SecuritySystem`: Polling to detect changes. New configuration `enablePolling` and `pollInterval`
+
 ## [1.0.4] - 2020-10-09
 ### Fixed 
 - Rename failed for LightBulb
   
 ## [1.0.3] - 2020-10-09
-
 ### Changed 
 - ACTION Necessary!!!
 - Change name of plugin from `S7` to `PLC`. Please rename your configuration. 
@@ -22,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Accessory StatelessProgrammableSwitch
 - Accessory SecuritySystem
-
 
 ## [1.0.2] - 2020-10-04
 ### Added 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed 
+- Change name of plugin from `S7` to `PLC` please rename your configuration. This step was necessary to avoid warning
+
+### Fixed 
+- Accessory Window and WindowCovering will shown as moving permanent (target position is now pushed immediately as current position)
+
+### Added
+- Accessory StatelessProgrammableSwitch
+- Accessory SecuritySystem
+
+
+## [1.0.1] - 2020-10-04
+### Added 
+- single bit on/off for S7_LightBulb S7_Outlet and S7_Faucet
+
+## [1.0.1] - 2020-10-04
+### Fixed 
+- finalize name change
+
+## [1.0.0] - 2020-10-04
+### Fixed 
+- change name of plugin from homebridge-S7_PLC to homebridge-plc homebridge denied to install
+
+## [0.0.1] - 2020-10-04
+### Added
+- Initial Version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.3] - 2020-10-09
 
 ### Changed 
-- Change name of plugin from `S7` to `PLC` please rename your configuration. This step was necessary to avoid warning
+- ACTION Necessary!!!
+- Change name of plugin from `S7` to `PLC`. Please rename your configuration. 
+- Remove prefix `S7_` from all accessories. Remove ist e.g. by STRG-H replace `S7_` by `PLC_` 
+- Fix spelling in parameter from `set_Deactive` to `set_Deactivate`
 
 ### Fixed 
 - Accessory Window and WindowCovering will shown as moving permanent (target position is now pushed immediately as current position)
@@ -17,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Accessory SecuritySystem
 
 
-## [1.0.1] - 2020-10-04
+## [1.0.2] - 2020-10-04
 ### Added 
 - single bit on/off for S7_LightBulb S7_Outlet and S7_Faucet
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2020-10-09
+### Fixed 
+- Rename failed for LightBulb
+  
 ## [1.0.3] - 2020-10-09
 
 ### Changed 

--- a/README.md
+++ b/README.md
@@ -37,54 +37,54 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
 - In the platform, you can declare different types of accessories currently supported:
     - `S7_LightBulb`: normal light
         - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) decription
+        - `manufacturer`: (optional) description
         - `db`: s7 data base number e.g. `4` for `DB4`
         - `get_On`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
         - Single Bit for on/off:
           - `set_On`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC  e.g. `55.0` for `DB4DBX55.0` could be same as get_On
-        - Seperate Bits for on/off:
+        - Separate Bits for on/off:
           - `set_On`: offset and bit set to 1 when switching on S7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
           - `set_Off`: offset and bit set to 1 when switching off S7 type `Bool` PLC has to set to 0 e.g. `55.2` for `DB4DBX55.2`   
         - `get_Brightness`: (optional) get brightness value S7 type `Byte` e.g. `56` for `DB4DBB56`    
-        - `set_Brightness`: (optional but reqired when `get_Brightness` is defined) set brightness value S7 type `Byte` e.g. `57` for `DB4DBB57`    
+        - `set_Brightness`: (optional but required when `get_Brightness` is defined) set brightness value S7 type `Byte` e.g. `57` for `DB4DBB57`    
 
 	- `S7_Outlet`: outlet possible to show also as ventilator or light
         - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) decription
+        - `manufacturer`: (optional) description
         - `db`: s7 data base number e.g. `4` for `DB4`
         - `get_On`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
         - Single Bit for on/off:
           - `set_On`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC  e.g. `55.0` for `DB4DBX55.0` could be same as get_On
-        - Seperate Bits for on/off:
+        - Separate Bits for on/off:
           - `set_On`: offset and bit set to 1 when switching on S7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
           - `set_Off`: offset and bit set to 1 when switching off S7 type `Bool` PLC has to set to 0 e.g. `55.2` for `DB4DBX55.2` 
 
 	- `S7_Switch`: switch possible to show also as ventilator or light
         - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) decription
+        - `manufacturer`: (optional) description
         - `db`: s7 data base number e.g. `4` for `DB4`
         - `get_On`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
         - Single Bit for on/off:
           - `set_On`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC  e.g. `55.0` for `DB4DBX55.0` could be same as get_On
-        - Seperate Bits for on/off:
+        - Separate Bits for on/off:
           - `set_On`: offset and bit set to 1 when switching on S7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
           - `set_Off`: offset and bit set to 1 when switching off S7 type `Bool` PLC has to set to 0 e.g. `55.2` for `DB4DBX55.2` 
 
-	- `S7_TemperatureSensor`: temerature sensor
+	- `S7_TemperatureSensor`: temperature sensor
 	    - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) decription
+        - `manufacturer`: (optional) description
         - `db`: s7 data base number e.g. `4` for `DB4`
         - `get_CurrentTemperature`: offset to get current temperature S7 type `Real` e.g. `55` for `DB4DBD55`  
 
 	- `S7_HumiditySensor`: humidity sensor 
 	    - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) decription
+        - `manufacturer`: (optional) description
         - `db`: s7 data base number e.g. `4` for `DB4`
         - `CurrentRelativeHumidity`: offset to get current humidity S7 type `Real` e.g. `55` for `DB4DBD55` 
 
-	- `S7_Thermostat`: temerature sensor and temperature regulation
+	- `S7_Thermostat`: temperature sensor and temperature regulation
 	    - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) decription
+        - `manufacturer`: (optional) description
         - `db`: s7 data base number e.g. `4` for `DB4`
         - `get_CurrentTemperature`: offset to get current humidity S7 type `Real` e.g. `55` for `DB4DBD55`  
         - S7 type `Byte` e.g. `56` for `DB4DBB56`  
@@ -105,7 +105,7 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
 
 	- `S7_WindowCovering`: windows and window blinds 
 	    - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) decription
+        - `manufacturer`: (optional) description
         - `db`: s7 data base number e.g. `4` for `DB4`
         - `invert`: set to 1 to inverts the meanings of the values from `0:closed 100:open` to `100:closed 0:open`
         - `get_CurrentPosition`: offset to get current position S7 type `Byte` e.g. `0` for `DB4DBB0`  
@@ -119,39 +119,39 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
 
 	- `S7_Window`: see S7_WindowCovering
 
-	- `S7_OccupancySensor`: precence sensor
+	- `S7_OccupancySensor`: presence sensor
 	    - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) decription
+        - `manufacturer`: (optional) description
         - `db`: s7 data base number e.g. `4` for `DB4`
         - `get_OccupancyDetected`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
 
 	- `S7_MotionSensor`: movement sensor
 	    - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) decription
+        - `manufacturer`: (optional) description
         - `db`: s7 data base number e.g. `4` for `DB4`
         - `get_MotionDetected`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
 
 	- `S7_Faucet`: watering for the garden 
 	    - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) decription
+        - `manufacturer`: (optional) description
         - `db`: s7 data base number e.g. `4` for `DB4`
         - `get_Active`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
         - Single Bit for on/off:
           - `set_Active`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC  e.g. `55.0` for `DB4DBX55.0` could be same as get_Active
-        - Seperate Bits for on/off:
+        - Separate Bits for on/off:
           - `set_Active`: offset and bit set to 1 when switching on S7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
-          - `set_Deactive`: offset and bit set to 1 when switching off S7 type `Bool` PLC has to set to 0 e.g. `55.2` for `DB4DBX55.2` 
+          - `set_Deactivate`: offset and bit set to 1 when switching off S7 type `Bool` PLC has to set to 0 e.g. `55.2` for `DB4DBX55.2` 
       
     -  `S7_SecuritySystem`: alarm system
 	    - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) decription
+        - `manufacturer`: (optional) description
         - `db`: s7 data base number e.g. `4` for `DB4`
         - `get_SecuritySystemCurrentState`: offset to current security system state S7 type `Byte` e.g. `3` for `DB4DBB3`    
           - `0`: armed stay at home
           - `1`: armed away from home
           - `2`: armed night 
           - `3`: disarmed
-          - `4`: alarm driggered
+          - `4`: alarm triggered
         - `set_SecuritySystemTargetState`: offset to set target security system state S7 type `Byte` e.g. `5` for `DB4DBB4`      
         - `get_SecuritySystemTargetState`: offset to set target security system state S7 type `Byte` e.g. `6` for `DB4DBB6`
           - `0`: armed stay at home
@@ -161,9 +161,9 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
     
     - `S7_Valve`: valve configurable as generic valve, irrigation, shower head or water faucet
 	    - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) decription
+        - `manufacturer`: (optional) description
         - `db`: s7 data base number e.g. `4` for `DB4`
-        - `ValveType` configures the valve type that is returend
+        - `ValveType` configures the valve type that is returned
           - `0`: generic valve
           - `1`: irrigation
           - `2`: shower head 
@@ -171,9 +171,9 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
         - `get_Active`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
         - Single Bit for on/off:
           - `set_Active`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC  e.g. `55.0` for `DB4DBX55.0` could be same as get_Active
-        - Seperate Bits for on/off:
+        - Separate Bits for on/off:
           - `set_Active`: offset and bit set to 1 when switching on S7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
-          - `set_Deactive`: offset and bit set to 1 when switching off S7 type `Bool` PLC has to set to 0 e.g. `55.2` for `DB4DBX55.2` 
+          - `set_Deactivate`: offset and bit set to 1 when switching off S7 type `Bool` PLC has to set to 0 e.g. `55.2` for `DB4DBX55.2` 
         - in can be fixed or dynamic together with active the device is shown in the home app as
           - Mapping table:
             - Active: 0  InUse: 0 -> off
@@ -185,14 +185,14 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
           - inUse dynamic
             - `get_InUse`: offset and bit get the current inUse state S7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
         - if one of the (optional) duration settings need specified all are needed
-          - `get_SetDuration`: (optional) duration towards homekit limit to 0..3600s ec S7 type `Time` e.g. `10` for `DB4DBD10`
-          - `set_SetDuration`: (optional) duration towards homekit limit to 0..3600s ec S7 type `Time` e.g. `14` for `DB4DBD14`
-          - `get_RemainingDuration`: (optional) duration towards homekit limit to 0..3600s ec S7 type `Time` e.g. `18` for `DB4DBD18`
+          - `get_SetDuration`: (optional) duration 0..3600 sec S7 type `Time` e.g. `10` for `DB4DBD10`
+          - `set_SetDuration`: (optional) duration 0..3600 sec S7 type `Time` e.g. `14` for `DB4DBD14`
+          - `get_RemainingDuration`: (optional) duration 0..3600 sec S7 type `Time` e.g. `18` for `DB4DBD18`
 
 
-    - `S7_StatelessProgrammableSwitch`: stateless switch from PLC to HomeKit to trigger actions in homekit only works with contol center e.g. AppleTV (Thus not yet tested)
+    - `S7_StatelessProgrammableSwitch`: stateless switch from PLC to HomeKit to trigger actions in homekit only works with control center e.g. AppleTV (Thus not yet tested)
 	    - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) decription
+        - `manufacturer`: (optional) description
         - `db`: s7 data base number e.g. `4` for `DB4`
         - `get_ProgrammableSwitchEvent`: offset to red current state of the switch S7 type `Byte` e.g. `3` for `DB4DBB3`  
           - `0`: single press
@@ -245,11 +245,11 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
                     "db": 6096,
                     "get_Active": 0.0
                     "set_Active": 1.1,
-                    "set_Deactive": 1.0,
+                    "set_Deactivate": 1.0,
                 }                
                 {
                     "accessory": "S7_OccupancySensor",
-                    "name": "Precence",
+                    "name": "Presence",
                     "db": 6510,
                     "get_OccupancyDetected": 24
                 },

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
 - Tested with S7-300 compatible PLC
 
 
-## Installation
+# Installation
 
 - Basic Installation
   - Install this plugin using: `npm install -g homebridge-plc`
@@ -27,178 +27,199 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
   - Click install.
   - Edit configuration
 
-## Homebridge configuration
+# Homebridge configuration
 
-- The plugin support the connection fo one PLC by defining a `S7` platform.
+## Platform
+
+The plugin is configured as single platform by defining a `PLC` platform.
+Parameters:
   - `ip`: the IPv4 address of the PLC
   - `rack`: the rack number of the PLC typically 0
   - `slot`: the slot number of the PLC for S7 300/400 typically `2`, for 1200/1500 typically `1` 
   
+
+## Accessories
 - In the platform, you can declare different types of accessories currently supported:
-    - `S7_LightBulb`: normal light
-        - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) description
-        - `db`: s7 data base number e.g. `4` for `DB4`
-        - `get_On`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
-        - Single Bit for on/off:
-          - `set_On`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC  e.g. `55.0` for `DB4DBX55.0` could be same as get_On
-        - Separate Bits for on/off:
-          - `set_On`: offset and bit set to 1 when switching on S7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
-          - `set_Off`: offset and bit set to 1 when switching off S7 type `Bool` PLC has to set to 0 e.g. `55.2` for `DB4DBX55.2`   
-        - `get_Brightness`: (optional) get brightness value S7 type `Byte` e.g. `56` for `DB4DBB56`    
-        - `set_Brightness`: (optional but required when `get_Brightness` is defined) set brightness value S7 type `Byte` e.g. `57` for `DB4DBB57`    
+### LightBulb as `PLC_LightBulb`
+normal light
+- `name`: unique name of the accessory 
+- `manufacturer`: (optional) description
+- `db`: s7 data base number e.g. `4` for `DB4`
+- `get_On`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
+- Single Bit for on/off:
+  - `set_On`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC  e.g. `55.0` for `DB4DBX55.0` could be same as get_On
+- Separate Bits for on/off:
+  - `set_On`: offset and bit set to 1 when switching on S7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
+  - `set_Off`: offset and bit set to 1 when switching off S7 type `Bool` PLC has to set to 0 e.g. `55.2` for `DB4DBX55.2`   
+- `get_Brightness`: (optional) get brightness value S7 type `Byte` e.g. `56` for `DB4DBB56`    
+- `set_Brightness`: (optional but required when `get_Brightness` is defined) set brightness value S7 type `Byte` e.g. `57` for `DB4DBB57`    
 
-	- `S7_Outlet`: outlet possible to show also as ventilator or light
-        - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) description
-        - `db`: s7 data base number e.g. `4` for `DB4`
-        - `get_On`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
-        - Single Bit for on/off:
-          - `set_On`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC  e.g. `55.0` for `DB4DBX55.0` could be same as get_On
-        - Separate Bits for on/off:
-          - `set_On`: offset and bit set to 1 when switching on S7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
-          - `set_Off`: offset and bit set to 1 when switching off S7 type `Bool` PLC has to set to 0 e.g. `55.2` for `DB4DBX55.2` 
+### Outlet as `PLC_Outlet`
+outlet possible to show also as ventilator or light
+- `name`: unique name of the accessory 
+- `manufacturer`: (optional) description
+- `db`: s7 data base number e.g. `4` for `DB4`
+- `get_On`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
+- Single Bit for on/off:
+    - `set_On`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC  e.g. `55.0` for `DB4DBX55.0` could be same as get_On
+- Separate Bits for on/off:
+    - `set_On`: offset and bit set to 1 when switching on S7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
+    - `set_Off`: offset and bit set to 1 when switching off S7 type `Bool` PLC has to set to 0 e.g. `55.2` for `DB4DBX55.2` 
 
-	- `S7_Switch`: switch possible to show also as ventilator or light
-        - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) description
-        - `db`: s7 data base number e.g. `4` for `DB4`
-        - `get_On`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
-        - Single Bit for on/off:
-          - `set_On`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC  e.g. `55.0` for `DB4DBX55.0` could be same as get_On
-        - Separate Bits for on/off:
-          - `set_On`: offset and bit set to 1 when switching on S7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
-          - `set_Off`: offset and bit set to 1 when switching off S7 type `Bool` PLC has to set to 0 e.g. `55.2` for `DB4DBX55.2` 
+### Switch as `PLC_Switch`
+ switch possible to show also as ventilator or light
+- `name`: unique name of the accessory 
+- `manufacturer`: (optional) description
+- `db`: s7 data base number e.g. `4` for `DB4`
+- `get_On`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
+- Single Bit for on/off:
+    - `set_On`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC  e.g. `55.0` for `DB4DBX55.0` could be same as get_On
+- Separate Bits for on/off:
+    - `set_On`: offset and bit set to 1 when switching on S7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
+    - `set_Off`: offset and bit set to 1 when switching off S7 type `Bool` PLC has to set to 0 e.g. `55.2` for `DB4DBX55.2` 
 
-	- `S7_TemperatureSensor`: temperature sensor
-	    - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) description
-        - `db`: s7 data base number e.g. `4` for `DB4`
-        - `get_CurrentTemperature`: offset to get current temperature S7 type `Real` e.g. `55` for `DB4DBD55`  
+### Temperature Sensor as `PLC_TemperatureSensor`: 
+normal temperature sensor
+- `name`: unique name of the accessory 
+- `manufacturer`: (optional) description
+- `db`: s7 data base number e.g. `4` for `DB4`
+- `get_CurrentTemperature`: offset to get current temperature S7 type `Real` e.g. `55` for `DB4DBD55`  
 
-	- `S7_HumiditySensor`: humidity sensor 
-	    - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) description
-        - `db`: s7 data base number e.g. `4` for `DB4`
-        - `CurrentRelativeHumidity`: offset to get current humidity S7 type `Real` e.g. `55` for `DB4DBD55` 
+### Humidity Sensor as `PLC_HumiditySensor`: 
+normal humidity sensor 
+- `name`: unique name of the accessory 
+- `manufacturer`: (optional) description
+- `db`: s7 data base number e.g. `4` for `DB4`
+- `CurrentRelativeHumidity`: offset to get current humidity S7 type `Real` e.g. `55` for `DB4DBD55` 
 
-	- `S7_Thermostat`: temperature sensor and temperature regulation
-	    - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) description
-        - `db`: s7 data base number e.g. `4` for `DB4`
-        - `get_CurrentTemperature`: offset to get current humidity S7 type `Real` e.g. `55` for `DB4DBD55`  
-        - S7 type `Byte` e.g. `56` for `DB4DBB56`  
-        - `get_CurrentTemperature`: offset to get current temperature S7 type `Real` e.g. `0` for `DB4DBD0`  
-        - `get_TargetTemperature`: offset to get target temperature S7 type `Real` e.g. `4` for `DB4DBD4`  
-        - `set_TargetTemperature`: offset to set current temperature S7 type `Real` e.g. `4` for `DB4DBD4` (can have same value as get_TargetTemperature)
-        - `get_CurrentHeaterCoolerState`: (optional) current heating/cooling state when not present fixed `1` is used S7 type `Byte` e.g. `8` for `DB4DBB58`    
-          - `0`: inactive
-          - `1`: idle
-          - `2`: heating
-          - `3`: cooling
-        - `get_TargetHeatingCoolingState` not yet supported returns fixes `3`
-          - `0`: off
-          - `1`: heat
-          - `2`: cool
-          - `3`: automatic
-        - `set_TargetHeatingCoolingState` not yet supported writes are ignored
+### Thermostat as `PLC_Thermostat`
+temperature sensor and temperature regulation
+- `name`: unique name of the accessory 
+- `manufacturer`: (optional) description
+- `db`: s7 data base number e.g. `4` for `DB4`
+- `get_CurrentTemperature`: offset to get current humidity S7 type `Real` e.g. `55` for `DB4DBD55`  
+- S7 type `Byte` e.g. `56` for `DB4DBB56`  
+- `get_CurrentTemperature`: offset to get current temperature S7 type `Real` e.g. `0` for `DB4DBD0`  
+- `get_TargetTemperature`: offset to get target temperature S7 type `Real` e.g. `4` for `DB4DBD4`  
+- `set_TargetTemperature`: offset to set current temperature S7 type `Real` e.g. `4` for `DB4DBD4` (can have same value as get_TargetTemperature)
+- `get_CurrentHeaterCoolerState`: (optional) current heating/cooling state when not present fixed `1` is used S7 type `Byte` e.g. `8` for `DB4DBB58`    
+    - `0`: inactive
+    - `1`: idle
+    - `2`: heating
+    - `3`: cooling
+- `get_TargetHeatingCoolingState` not yet supported returns fixes `3`
+    - `0`: off
+    - `1`: heat
+    - `2`: cool
+    - `3`: automatic
+- `set_TargetHeatingCoolingState` not yet supported writes are ignored
 
-	- `S7_WindowCovering`: windows and window blinds 
-	    - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) description
-        - `db`: s7 data base number e.g. `4` for `DB4`
-        - `invert`: set to 1 to inverts the meanings of the values from `0:closed 100:open` to `100:closed 0:open`
-        - `get_CurrentPosition`: offset to get current position S7 type `Byte` e.g. `0` for `DB4DBB0`  
-        - `get_TargetPosition`: (optional for windows) offset to get target position S7 type `Byte` e.g. `1` for `DB4DBB1`  
-        - `set_TargetPosition`: (optional for windows) offset to set current position S7 type `Byte` e.g. `2` for `DB4DBB2` (can have same value as set_TargetPosition)
-        - `get_PositionState`: (optional) offset to current movement state if not defined fixed `2`is returned S7 type `Byte` e.g. `3` for `DB4DBB3`    
-          - `0`: down
-          - `1`: up
-          - `2`: stop
-        - `set_HoldPosition`: (optional): offset and bit set to 1 to stop movement. (Seems not to be used) when not defined writes will be ignoredS7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
+### Shutters as `PLC_WindowCovering`
+shutters or blinds
+- `name`: unique name of the accessory 
+- `manufacturer`: (optional) description
+- `db`: s7 data base number e.g. `4` for `DB4`
+- `invert`: set to 1 to inverts the meanings of the values from `0:closed 100:open` to `100:closed 0:open`
+- `get_CurrentPosition`: offset to get current position S7 type `Byte` e.g. `0` for `DB4DBB0`  
+- `get_TargetPosition`: (optional for windows) offset to get target position S7 type `Byte` e.g. `1` for `DB4DBB1`  
+- `set_TargetPosition`: (optional for windows) offset to set current position S7 type `Byte` e.g. `2` for `DB4DBB2` (can have same value as set_TargetPosition)
+- `get_PositionState`: (optional) offset to current movement state if not defined fixed `2`is returned S7 type `Byte` e.g. `3` for `DB4DBB3`    
+    - `0`: down
+    - `1`: up
+    - `2`: stop
+- `set_HoldPosition`: (optional): offset and bit set to 1 to stop movement. (Seems not to be used) when not defined writes will be ignoredS7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
 
-	- `S7_Window`: see S7_WindowCovering
+### Windows as `PLC_Window`
+sensors for windows
+- `name`: unique name of the accessory 
+- `manufacturer`: (optional) description
+- `db`: s7 data base number e.g. `4` for `DB4`
+- `invert`: set to 1 to inverts the meanings of the values from `0:closed 100:open` to `100:closed 0:open`
+- `get_CurrentPosition`: offset to get current position S7 type `Byte` e.g. `0` for `DB4DBB0`  
+- `get_TargetPosition`: (optional for windows) offset to get target position S7 type `Byte` e.g. `1` for `DB4DBB1`  
+- `set_TargetPosition`: (optional for windows) offset to set current position S7 type `Byte` e.g. `2` for `DB4DBB2` (can have same value as set_TargetPosition)
+- `get_PositionState`: (optional) offset to current movement state if not defined fixed `2` is returned S7 type `Byte` e.g. `3` for `DB4DBB3`    
+    - `0`: down
+    - `1`: up
+    - `2`: stop
+- `set_HoldPosition`: (optional): offset and bit set to 1 to stop movement. (Seems not to be used) when not defined writes will be ignoredS7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
+  
+### Occupancy Sensor as `PLC_OccupancySensor`
+presence detection sensor
+- `name`: unique name of the accessory 
+- `manufacturer`: (optional) description
+- `db`: s7 data base number e.g. `4` for `DB4`
+- `get_OccupancyDetected`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
 
-	- `S7_OccupancySensor`: presence sensor
-	    - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) description
-        - `db`: s7 data base number e.g. `4` for `DB4`
-        - `get_OccupancyDetected`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
+### Motion Sensor as `PLC_MotionSensor`
+movement detection sensor
+- `name`: unique name of the accessory 
+- `manufacturer`: (optional) description
+- `db`: s7 data base number e.g. `4` for `DB4`
+- `get_MotionDetected`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
 
-	- `S7_MotionSensor`: movement sensor
-	    - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) description
-        - `db`: s7 data base number e.g. `4` for `DB4`
-        - `get_MotionDetected`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
+### Faucet as `PLC_Faucet`
+watering for the garden 
+- `name`: unique name of the accessory 
+- `manufacturer`: (optional) description
+- `db`: s7 data base number e.g. `4` for `DB4`
+- `get_Active`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
+- Single Bit for on/off:
+    - `set_Active`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC  e.g. `55.0` for `DB4DBX55.0` could be same as get_Active
+- Separate Bits for on/off:
+    - `set_Active`: offset and bit set to 1 when switching on S7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
+    - `set_Deactivate`: offset and bit set to 1 when switching off S7 type `Bool` PLC has to set to 0 e.g. `55.2` for `DB4DBX55.2` 
 
-	- `S7_Faucet`: watering for the garden 
-	    - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) description
-        - `db`: s7 data base number e.g. `4` for `DB4`
-        - `get_Active`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
-        - Single Bit for on/off:
-          - `set_Active`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC  e.g. `55.0` for `DB4DBX55.0` could be same as get_Active
-        - Separate Bits for on/off:
-          - `set_Active`: offset and bit set to 1 when switching on S7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
-          - `set_Deactivate`: offset and bit set to 1 when switching off S7 type `Bool` PLC has to set to 0 e.g. `55.2` for `DB4DBX55.2` 
-      
-    -  `S7_SecuritySystem`: alarm system
-	    - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) description
-        - `db`: s7 data base number e.g. `4` for `DB4`
-        - `get_SecuritySystemCurrentState`: offset to current security system state S7 type `Byte` e.g. `3` for `DB4DBB3`    
-          - `0`: armed stay at home
-          - `1`: armed away from home
-          - `2`: armed night 
-          - `3`: disarmed
-          - `4`: alarm triggered
-        - `set_SecuritySystemTargetState`: offset to set target security system state S7 type `Byte` e.g. `5` for `DB4DBB4`      
-        - `get_SecuritySystemTargetState`: offset to set target security system state S7 type `Byte` e.g. `6` for `DB4DBB6`
-          - `0`: armed stay at home
-          - `1`: armed away from home
-          - `2`: armed night 
-          - `3`: disarmed
-    
-    - `S7_Valve`: valve configurable as generic valve, irrigation, shower head or water faucet
-	    - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) description
-        - `db`: s7 data base number e.g. `4` for `DB4`
-        - `ValveType` configures the valve type that is returned
-          - `0`: generic valve
-          - `1`: irrigation
-          - `2`: shower head 
-          - `3`: water faucet
-        - `get_Active`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
-        - Single Bit for on/off:
-          - `set_Active`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC  e.g. `55.0` for `DB4DBX55.0` could be same as get_Active
-        - Separate Bits for on/off:
-          - `set_Active`: offset and bit set to 1 when switching on S7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
-          - `set_Deactivate`: offset and bit set to 1 when switching off S7 type `Bool` PLC has to set to 0 e.g. `55.2` for `DB4DBX55.2` 
-        - in can be fixed or dynamic together with active the device is shown in the home app as
-          - Mapping table:
-            - Active: 0  InUse: 0 -> off
-            - Active: 0  InUse: 1 -> stopping
-            - Active: 1  InUse: 0 -> idle
-            - Active: 1  InUse: 1 -> running
-          - inUse fixed
-            - `InUse`: fixed value `0` or `1`
-          - inUse dynamic
-            - `get_InUse`: offset and bit get the current inUse state S7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
-        - if one of the (optional) duration settings need specified all are needed
-          - `get_SetDuration`: (optional) duration 0..3600 sec S7 type `Time` e.g. `10` for `DB4DBD10`
-          - `set_SetDuration`: (optional) duration 0..3600 sec S7 type `Time` e.g. `14` for `DB4DBD14`
-          - `get_RemainingDuration`: (optional) duration 0..3600 sec S7 type `Time` e.g. `18` for `DB4DBD18`
+###  Security System as `PLC_SecuritySystem`:
+alarm system
+- `name`: unique name of the accessory 
+- `manufacturer`: (optional) description
+- `db`: s7 data base number e.g. `4` for `DB4`
+- `get_SecuritySystemCurrentState`: offset to current security system state S7 type `Byte` e.g. `3` for `DB4DBB3`    
+    - `0`: armed stay at home
+    - `1`: armed away from home
+    - `2`: armed night 
+    - `3`: disarmed
+    - `4`: alarm triggered
+- `set_SecuritySystemTargetState`: offset to set target security system state S7 type `Byte` e.g. `5` for `DB4DBB4`      
+- `get_SecuritySystemTargetState`: offset to set target security system state S7 type `Byte` e.g. `6` for `DB4DBB6`
+    - `0`: armed stay at home
+    - `1`: armed away from home
+    - `2`: armed night 
+    - `3`: disarmed
+
+### Valve as `PLC_Valve`
+valve configurable as generic valve, irrigation, shower head or water faucet
+- `name`: unique name of the accessory 
+- `manufacturer`: (optional) description
+- `db`: s7 data base number e.g. `4` for `DB4`
+- `ValveType` configures the valve type that is returned
+    - `0`: generic valve
+    - `1`: irrigation
+    - `2`: shower head 
+    - `3`: water faucet
+- `get_Active`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
+- Single Bit for on/off:
+    - `set_Active`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC  e.g. `55.0` for `DB4DBX55.0` could be same as get_Active
+- Separate Bits for on/off:
+    - `set_Active`: offset and bit set to 1 when switching on S7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
+    - `set_Deactivate`: offset and bit set to 1 when switching off S7 type `Bool` PLC has to set to 0 e.g. `55.2` for `DB4DBX55.2` 
+- if one of the (optional) duration settings need specified all are needed
+    - `get_SetDuration`: (optional) duration 0..3600 sec S7 type `Time` e.g. `10` for `DB4DBD10`
+    - `set_SetDuration`: (optional) duration 0..3600 sec S7 type `Time` e.g. `14` for `DB4DBD14`
+    - `get_RemainingDuration`: (optional) duration 0..3600 sec S7 type `Time` e.g. `18` for `DB4DBD18`
 
 
-    - `S7_StatelessProgrammableSwitch`: stateless switch from PLC to HomeKit to trigger actions in homekit only works with control center e.g. AppleTV (Thus not yet tested)
-	    - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) description
-        - `db`: s7 data base number e.g. `4` for `DB4`
-        - `get_ProgrammableSwitchEvent`: offset to red current state of the switch S7 type `Byte` e.g. `3` for `DB4DBB3`  
-          - `0`: single press
-          - `1`: double press
-          - `2`: long press
-          - I have no idea what to send when there was no press!?
+### Button as `PLC_StatelessProgrammableSwitch`
+stateless switch from PLC to HomeKit to trigger actions in homekit only works with control center e.g. AppleTV (Thus not yet tested)
+- `name`: unique name of the accessory 
+- `manufacturer`: (optional) description
+- `db`: s7 data base number e.g. `4` for `DB4`
+- `get_ProgrammableSwitchEvent`: offset to red current state of the switch S7 type `Byte` e.g. `3` for `DB4DBB3`  
+    - `0`: single press
+    - `1`: double press
+    - `2`: long press
+    - I have no idea what to send when there was no press!?
 
 
 
@@ -206,13 +227,13 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
     {
         "platforms": [
             {
-            "platform": "S7",
+            "platform": "PLC",
             "ip": "10.10.10.32",
             "rack": 0,
             "slot": 2,
             "accessories": [
                 {
-                    "accessory": "S7_LightBulb",
+                    "accessory": "PLC_LightBulb",
                     "name": "myRoom",
                     "manufacturer": "normal light bulb",
                     "db": 6061,
@@ -221,7 +242,7 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
                     "set_Off": 1.0,
                 },
                 {
-                    "accessory": "S7_LightBulb",
+                    "accessory": "PLC_LightBulb",
                     "name": "myNextRoom",
                     "manufacturer": "with dim function",
                     "db": 6062,
@@ -232,7 +253,7 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
                     "set_Brightness": 4
                 },                
                 {
-                    "accessory": "S7_LightBulb",
+                    "accessory": "PLC_LightBulb",
                     "name": "someOther",
                     "manufacturer": "single bit for on/off",
                     "db": 6094,
@@ -240,7 +261,7 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
                     "set_On": 1.1
                 },
                 {
-                    "accessory": "S7_Faucet",
+                    "accessory": "PLC_Faucet",
                     "name": "Garden",
                     "db": 6096,
                     "get_Active": 0.0
@@ -248,13 +269,13 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
                     "set_Deactivate": 1.0,
                 }                
                 {
-                    "accessory": "S7_OccupancySensor",
+                    "accessory": "PLC_OccupancySensor",
                     "name": "Presence",
                     "db": 6510,
                     "get_OccupancyDetected": 24
                 },
                 {
-                    "accessory": "S7_Outlet",
+                    "accessory": "PLC_Outlet",
                     "name": "myOutlet",
                     "db": 6107,
                     "get_On": 0.0,
@@ -262,14 +283,14 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
                     "set_Off": 1.0
                 },
                 {
-                    "accessory": "S7_HumiditySensor",
+                    "accessory": "PLC_HumiditySensor",
                     "name": "Outside %",
                     "manufacturer": "roof",
                     "db": 1901,
                     "get_CurrentRelativeHumidity": 16
                 },
                 {
-                    "accessory": "S7_Thermostat",
+                    "accessory": "PLC_Thermostat",
                     "name": "myRoom °C",
                     "manufacturer": "ground floor",
                     "db": 6601,
@@ -279,7 +300,7 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
                     "get_CurrentHeaterCoolerState": 10
                 },             
                 {
-                    "accessory": "S7_WindowCovering",
+                    "accessory": "PLC_WindowCovering",
                     "name": "myRoom Blind",
                     "manufacturer": "ground floor",
                     "db": 2602,
@@ -291,7 +312,7 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
                     "set_HoldPosition": 10.4
                 },
                 {
-                    "accessory": "S7_StatelessProgrammableSwitch",
+                    "accessory": "PLC_StatelessProgrammableSwitch",
                     "name": "test ",
                     "manufacturer": "DG",
                     "db": 2,
@@ -302,7 +323,7 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
 
                 {
                     /* Not yet tested */
-                    "accessory": "S7_StatelessProgrammableSwitch",
+                    "accessory": "PLC_StatelessProgrammableSwitch",
                     "name": "NotYetTested",
                     "db": 2,
                     "get_ProgrammableSwitchEvent": 0

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Parameters:
   - `ip`: the IPv4 address of the PLC
   - `rack`: the rack number of the PLC typically 0
   - `slot`: the slot number of the PLC for S7 300/400 typically `2`, for 1200/1500 typically `1` 
+  - `enablePolling`: when set to `true` a background task is executed every second enable polling for the accessories
   
 
 ## Accessories
@@ -119,7 +120,9 @@ shutters or blinds
 - `name`: unique name of the accessory 
 - `manufacturer`: (optional) description
 - `db`: s7 data base number e.g. `4` for `DB4`
-- `invert`: set to 1 to inverts the meanings of the values from `0:closed 100:open` to `100:closed 0:open`
+- `invert`: (optional) set to `true` to inverts the meanings of the values from `0:closed 100:open` to `100:closed 0:open`
+- `adaptivePolling`:  (optional) hen set to `true` the current position will be polled until target position is reached. Polling starts with set target position from home app. This will show the shutter as opening... or closing... in the home app. Otherwise the new target position is directly pushed as new current position.
+- `pollInterval` (optional) poll interval in seconds. Default value is `10` seconds.
 - `get_CurrentPosition`: offset to get current position S7 type `Byte` e.g. `0` for `DB4DBB0`  
 - `get_TargetPosition`: (optional for windows) offset to get target position S7 type `Byte` e.g. `1` for `DB4DBB1`  
 - `set_TargetPosition`: (optional for windows) offset to set current position S7 type `Byte` e.g. `2` for `DB4DBB2` (can have same value as set_TargetPosition)
@@ -187,6 +190,10 @@ alarm system
     - `1`: armed away from home
     - `2`: armed night 
     - `3`: disarmed
+- `enablePolling`:  (optional) when set to `true` the current State of the security system will be polled. When disabled a set of the target system state will push it also as current system state. 
+- `pollInterval` (optional) poll interval in seconds. Default value is `10` seconds.
+
+
 
 ### Valve as `PLC_Valve`
 valve configurable as generic valve, irrigation, shower head or water faucet
@@ -209,7 +216,6 @@ valve configurable as generic valve, irrigation, shower head or water faucet
     - `set_SetDuration`: (optional) duration 0..3600 sec S7 type `Time` e.g. `14` for `DB4DBD14`
     - `get_RemainingDuration`: (optional) duration 0..3600 sec S7 type `Time` e.g. `18` for `DB4DBD18`
 
-
 ### Button as `PLC_StatelessProgrammableSwitch`
 stateless switch from PLC to HomeKit to trigger actions in homekit only works with control center e.g. AppleTV (Thus not yet tested)
 - `name`: unique name of the accessory 
@@ -222,7 +228,6 @@ stateless switch from PLC to HomeKit to trigger actions in homekit only works wi
     - I have no idea what to send when there was no press!?
 
 
-
 #### Config.json Example
     {
         "platforms": [
@@ -231,6 +236,7 @@ stateless switch from PLC to HomeKit to trigger actions in homekit only works wi
             "ip": "10.10.10.32",
             "rack": 0,
             "slot": 2,
+            "enablePolling": true;
             "accessories": [
                 {
                     "accessory": "PLC_LightBulb",
@@ -304,7 +310,9 @@ stateless switch from PLC to HomeKit to trigger actions in homekit only works wi
                     "name": "myRoom Blind",
                     "manufacturer": "ground floor",
                     "db": 2602,
-                    "invert": 1,
+                    "invert": true,
+                    "adaptivePolling": true,
+                    "pollInterval": 10,
                     "get_CurrentPosition": 0,
                     "get_TargetPosition": 1,
                     "set_TargetPosition": 1,
@@ -312,13 +320,14 @@ stateless switch from PLC to HomeKit to trigger actions in homekit only works wi
                     "set_HoldPosition": 10.4
                 },
                 {
-                    "accessory": "PLC_StatelessProgrammableSwitch",
-                    "name": "test ",
-                    "manufacturer": "DG",
+                    "accessory": "PLC_SecuritySystem",
+                    "name": "AlarmSystem",
                     "db": 2,
-                    "get_SecuritySystemCurrentState": 0,
-                    "set_SecuritySystemTargetState": 1,
-                    "get_SecuritySystemTargetState": 1
+                    "enablePolling": true,
+                    "pollInterval": 60,
+                    "get_SecuritySystemCurrentState": 1,
+                    "set_SecuritySystemTargetState": 2,
+                    "get_SecuritySystemTargetState": 2
                 },
 
                 {

--- a/README.md
+++ b/README.md
@@ -33,12 +33,13 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
   - `ip`: the IPv4 address of the PLC
   - `rack`: the rack number of the PLC typically 0
   - `slot`: the slot number of the PLC for S7 300/400 typically `2`, for 1200/1500 typically `1` 
-- in the platform, you can declare different types of accessories currently supported:
+  
+- In the platform, you can declare different types of accessories currently supported:
     - `S7_LightBulb`: normal light
         - `name`: unique name of the accessory 
         - `manufacturer`: (optional) decription
         - `db`: s7 data base number e.g. `4` for `DB4`
-        - `get_On`: offset and bit set get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
+        - `get_On`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
         - Single Bit for on/off:
           - `set_On`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC  e.g. `55.0` for `DB4DBX55.0` could be same as get_On
         - Seperate Bits for on/off:
@@ -46,25 +47,47 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
           - `set_Off`: offset and bit set to 1 when switching off S7 type `Bool` PLC has to set to 0 e.g. `55.2` for `DB4DBX55.2`   
         - `get_Brightness`: (optional) get brightness value S7 type `Byte` e.g. `56` for `DB4DBB56`    
         - `set_Brightness`: (optional but reqired when `get_Brightness` is defined) set brightness value S7 type `Byte` e.g. `57` for `DB4DBB57`    
-	- `S7_Outlet`: outlet, ventilator or light
+
+	- `S7_Outlet`: outlet possible to show also as ventilator or light
         - `name`: unique name of the accessory 
         - `manufacturer`: (optional) decription
         - `db`: s7 data base number e.g. `4` for `DB4`
-        - `get_On`: offset and bit set get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
+        - `get_On`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
         - Single Bit for on/off:
           - `set_On`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC  e.g. `55.0` for `DB4DBX55.0` could be same as get_On
         - Seperate Bits for on/off:
           - `set_On`: offset and bit set to 1 when switching on S7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
           - `set_Off`: offset and bit set to 1 when switching off S7 type `Bool` PLC has to set to 0 e.g. `55.2` for `DB4DBX55.2` 
+
+	- `S7_Switch`: switch possible to show also as ventilator or light
+        - `name`: unique name of the accessory 
+        - `manufacturer`: (optional) decription
+        - `db`: s7 data base number e.g. `4` for `DB4`
+        - `get_On`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
+        - Single Bit for on/off:
+          - `set_On`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC  e.g. `55.0` for `DB4DBX55.0` could be same as get_On
+        - Seperate Bits for on/off:
+          - `set_On`: offset and bit set to 1 when switching on S7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
+          - `set_Off`: offset and bit set to 1 when switching off S7 type `Bool` PLC has to set to 0 e.g. `55.2` for `DB4DBX55.2` 
+
 	- `S7_TemperatureSensor`: temerature sensor
 	    - `name`: unique name of the accessory 
         - `manufacturer`: (optional) decription
         - `db`: s7 data base number e.g. `4` for `DB4`
         - `get_CurrentTemperature`: offset to get current temperature S7 type `Real` e.g. `55` for `DB4DBD55`  
+
 	- `S7_HumiditySensor`: humidity sensor 
 	    - `name`: unique name of the accessory 
         - `manufacturer`: (optional) decription
         - `db`: s7 data base number e.g. `4` for `DB4`
+        - `CurrentRelativeHumidity`: offset to get current humidity S7 type `Real` e.g. `55` for `DB4DBD55` 
+
+	- `S7_Thermostat`: temerature sensor and temperature regulation
+	    - `name`: unique name of the accessory 
+        - `manufacturer`: (optional) decription
+        - `db`: s7 data base number e.g. `4` for `DB4`
+        - `get_CurrentTemperature`: offset to get current humidity S7 type `Real` e.g. `55` for `DB4DBD55`  
+        - S7 type `Byte` e.g. `56` for `DB4DBB56`  
         - `get_CurrentTemperature`: offset to get current temperature S7 type `Real` e.g. `0` for `DB4DBD0`  
         - `get_TargetTemperature`: offset to get target temperature S7 type `Real` e.g. `4` for `DB4DBD4`  
         - `set_TargetTemperature`: offset to set current temperature S7 type `Real` e.g. `4` for `DB4DBD4` (can have same value as get_TargetTemperature)
@@ -79,12 +102,7 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
           - `2`: cool
           - `3`: automatic
         - `set_TargetHeatingCoolingState` not yet supported writes are ignored
-	- `S7_Thermostat`: temerature sensor and temperature regulation
-	    - `name`: unique name of the accessory 
-        - `manufacturer`: (optional) decription
-        - `db`: s7 data base number e.g. `4` for `DB4`
-        - `get_CurrentTemperature`: offset to get current humidity S7 type `Real` e.g. `55` for `DB4DBD55`  
-        - S7 type `Byte` e.g. `56` for `DB4DBB56`  
+
 	- `S7_WindowCovering`: windows and window blinds 
 	    - `name`: unique name of the accessory 
         - `manufacturer`: (optional) decription
@@ -98,28 +116,90 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
           - `1`: up
           - `2`: stop
         - `set_HoldPosition`: (optional): offset and bit set to 1 to stop movement. (Seems not to be used) when not defined writes will be ignoredS7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
+
 	- `S7_Window`: see S7_WindowCovering
+
 	- `S7_OccupancySensor`: precence sensor
 	    - `name`: unique name of the accessory 
         - `manufacturer`: (optional) decription
         - `db`: s7 data base number e.g. `4` for `DB4`
-        - `get_OccupancyDetected`: offset and bit set get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
+        - `get_OccupancyDetected`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
+
 	- `S7_MotionSensor`: movement sensor
 	    - `name`: unique name of the accessory 
         - `manufacturer`: (optional) decription
         - `db`: s7 data base number e.g. `4` for `DB4`
-        - `get_MotionDetected`: offset and bit set get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
+        - `get_MotionDetected`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
+
 	- `S7_Faucet`: watering for the garden 
 	    - `name`: unique name of the accessory 
         - `manufacturer`: (optional) decription
         - `db`: s7 data base number e.g. `4` for `DB4`
-        - `get_Active`: offset and bit set get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
+        - `get_Active`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
         - Single Bit for on/off:
           - `set_Active`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC  e.g. `55.0` for `DB4DBX55.0` could be same as get_Active
         - Seperate Bits for on/off:
           - `set_Active`: offset and bit set to 1 when switching on S7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
           - `set_Deactive`: offset and bit set to 1 when switching off S7 type `Bool` PLC has to set to 0 e.g. `55.2` for `DB4DBX55.2` 
+      
+    -  `S7_SecuritySystem`: alarm system
+	    - `name`: unique name of the accessory 
+        - `manufacturer`: (optional) decription
+        - `db`: s7 data base number e.g. `4` for `DB4`
+        - `get_SecuritySystemCurrentState`: offset to current security system state S7 type `Byte` e.g. `3` for `DB4DBB3`    
+          - `0`: armed stay at home
+          - `1`: armed away from home
+          - `2`: armed night 
+          - `3`: disarmed
+          - `4`: alarm driggered
+        - `set_SecuritySystemTargetState`: offset to set target security system state S7 type `Byte` e.g. `5` for `DB4DBB4`      
+        - `get_SecuritySystemTargetState`: offset to set target security system state S7 type `Byte` e.g. `6` for `DB4DBB6`
+          - `0`: armed stay at home
+          - `1`: armed away from home
+          - `2`: armed night 
+          - `3`: disarmed
     
+    - `S7_Valve`: valve configurable as generic valve, irrigation, shower head or water faucet
+	    - `name`: unique name of the accessory 
+        - `manufacturer`: (optional) decription
+        - `db`: s7 data base number e.g. `4` for `DB4`
+        - `ValveType` configures the valve type that is returend
+          - `0`: generic valve
+          - `1`: irrigation
+          - `2`: shower head 
+          - `3`: water faucet
+        - `get_Active`: offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`        
+        - Single Bit for on/off:
+          - `set_Active`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC  e.g. `55.0` for `DB4DBX55.0` could be same as get_Active
+        - Seperate Bits for on/off:
+          - `set_Active`: offset and bit set to 1 when switching on S7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
+          - `set_Deactive`: offset and bit set to 1 when switching off S7 type `Bool` PLC has to set to 0 e.g. `55.2` for `DB4DBX55.2` 
+        - in can be fixed or dynamic together with active the device is shown in the home app as
+          - Mapping table:
+            - Active: 0  InUse: 0 -> off
+            - Active: 0  InUse: 1 -> stopping
+            - Active: 1  InUse: 0 -> idle
+            - Active: 1  InUse: 1 -> running
+          - inUse fixed
+            - `InUse`: fixed value `0` or `1`
+          - inUse dynamic
+            - `get_InUse`: offset and bit get the current inUse state S7 type `Bool` PLC has to set to 0 e.g. `55.1` for `DB4DBX55.1`
+        - if one of the (optional) duration settings need specified all are needed
+          - `get_SetDuration`: (optional) duration towards homekit limit to 0..3600s ec S7 type `Time` e.g. `10` for `DB4DBD10`
+          - `set_SetDuration`: (optional) duration towards homekit limit to 0..3600s ec S7 type `Time` e.g. `14` for `DB4DBD14`
+          - `get_RemainingDuration`: (optional) duration towards homekit limit to 0..3600s ec S7 type `Time` e.g. `18` for `DB4DBD18`
+
+
+    - `S7_StatelessProgrammableSwitch`: stateless switch from PLC to HomeKit to trigger actions in homekit only works with contol center e.g. AppleTV (Thus not yet tested)
+	    - `name`: unique name of the accessory 
+        - `manufacturer`: (optional) decription
+        - `db`: s7 data base number e.g. `4` for `DB4`
+        - `get_ProgrammableSwitchEvent`: offset to red current state of the switch S7 type `Byte` e.g. `3` for `DB4DBB3`  
+          - `0`: single press
+          - `1`: double press
+          - `2`: long press
+          - I have no idea what to send when there was no press!?
+
 
 
 #### Config.json Example
@@ -209,7 +289,24 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
                     "set_TargetPosition": 1,
                     "get_PositionState": 2,
                     "set_HoldPosition": 10.4
-                }   
+                },
+                {
+                    "accessory": "S7_StatelessProgrammableSwitch",
+                    "name": "test ",
+                    "manufacturer": "DG",
+                    "db": 2,
+                    "get_SecuritySystemCurrentState": 0,
+                    "set_SecuritySystemTargetState": 1,
+                    "get_SecuritySystemTargetState": 1
+                },
+
+                {
+                    /* Not yet tested */
+                    "accessory": "S7_StatelessProgrammableSwitch",
+                    "name": "NotYetTested",
+                    "db": 2,
+                    "get_ProgrammableSwitchEvent": 0
+                }                   
             ]
         }
         ]

--- a/index.js
+++ b/index.js
@@ -12,10 +12,10 @@ module.exports = function(homebridge) {
   Characteristic = homebridge.hap.Characteristic;
   UUIDGen = homebridge.hap.uuid;
   PlatformAccessory = homebridge.platformAccessory;
-  homebridge.registerPlatform(platformName, 'S7', S7Platform);
+  homebridge.registerPlatform(platformName, 'PLC', PLC_Platform);
 }
 
-function S7Platform(log, config) {
+function PLC_Platform(log, config) {
     this.log = log;
     this.config = config;
     this.S7Client = new snap7.S7Client();
@@ -23,16 +23,16 @@ function S7Platform(log, config) {
     this.S7ClientConnect();
 }
 
-S7Platform.prototype = {    
+PLC_Platform.prototype = {    
     accessories: function(callback) {
         var log = this.log;
         var s7PlatformAccessories = [];
-        log("Add S7 accessories...");
+        log("Add PLC accessories...");
         //create accessory for each configuration
         this.config.accessories.forEach((config, index) => {
             log("[" + String(index+1) + "/" + this.config.accessories.length + "] " + config.name + " (" +  config.accessory + ")" );
             //call accessory construction
-            var accessory = new GenericS7(this, config);
+            var accessory = new GenericPLCAccessory(this, config);
             s7PlatformAccessories.push(accessory);
         });
         callback(s7PlatformAccessories);
@@ -56,7 +56,6 @@ S7Platform.prototype = {
 
             if (!this.isConnectOngoing == true) {
               this.isConnectOngoing = true;
-                //PLC connection asynchonousely...
                 var ok = S7Client.ConnectTo(ip, rack, slot);
                 this.isConnectOngoing = false;
                 if(ok) {
@@ -78,7 +77,7 @@ S7Platform.prototype = {
 
 
 
-function GenericS7(platform, config) {
+function GenericPLCAccessory(platform, config) {
   this.platform = platform;
   this.log = platform.log;
   this.name = config.name;
@@ -88,7 +87,7 @@ function GenericS7(platform, config) {
   ////////////////////////////////////////////////////////////////
   // Lightbulb
   ////////////////////////////////////////////////////////////////
-  if (config.accessory == 'S7_LightBulb') {   
+  if (config.accessory == 'PLC_PLC_LightBulb') {   
     this.service =  new Service.Lightbulb(this.name);
     this.accessory.addService(this.service);
 
@@ -142,7 +141,7 @@ function GenericS7(platform, config) {
   ////////////////////////////////////////////////////////////////
   // Outlet
   ////////////////////////////////////////////////////////////////    
-  else if (config.accessory == 'S7_Outlet') {   
+  else if (config.accessory == 'PLC_Outlet') {   
     this.service =  new Service.Outlet(this.name);
     this.accessory.addService(this.service);
 
@@ -178,7 +177,7 @@ function GenericS7(platform, config) {
   ////////////////////////////////////////////////////////////////
   // Switch
   ////////////////////////////////////////////////////////////////    
-  else if (config.accessory == 'S7_Switch') {   
+  else if (config.accessory == 'PLC_Switch') {   
     this.service =  new Service.Switch(this.name);
     this.accessory.addService(this.service);
 
@@ -213,7 +212,7 @@ function GenericS7(platform, config) {
   ////////////////////////////////////////////////////////////////
   // TemperatureSensor
   //////////////////////////////////////////////////////////////// 
-  else if (config.accessory == 'S7_TemperatureSensor') {   
+  else if (config.accessory == 'PLC_TemperatureSensor') {   
     this.service =  new Service.TemperatureSensor(this.name);
     this.accessory.addService(this.service);
 
@@ -233,7 +232,7 @@ function GenericS7(platform, config) {
   ////////////////////////////////////////////////////////////////
   // HumiditySensor
   //////////////////////////////////////////////////////////////// 
-  else if (config.accessory == 'S7_HumiditySensor') {   
+  else if (config.accessory == 'PLC_HumiditySensor') {   
     this.service =  new Service.HumiditySensor(this.name);
     this.accessory.addService(this.service);
 
@@ -253,7 +252,7 @@ function GenericS7(platform, config) {
   ////////////////////////////////////////////////////////////////
   // Thermostat
   ////////////////////////////////////////////////////////////////  
-  else if (config.accessory == 'S7_Thermostat'){
+  else if (config.accessory == 'PLC_Thermostat'){
     this.service = new Service.Thermostat(this.name);
     this.accessory.addService(this.service);
 
@@ -319,8 +318,8 @@ function GenericS7(platform, config) {
  ////////////////////////////////////////////////////////////////
   // Window and WindowCovering
   ////////////////////////////////////////////////////////////////    
-  else if (config.accessory == 'S7_Window' ||config.accessory == 'S7_WindowCovering'){ 
-    if (config.accessory == 'S7_Window')
+  else if (config.accessory == 'PLC_Window' ||config.accessory == 'PLC_WindowCovering'){ 
+    if (config.accessory == 'PLC_Window')
     {
       this.service = new Service.Window(this.name);
     }
@@ -405,7 +404,7 @@ function GenericS7(platform, config) {
   ////////////////////////////////////////////////////////////////
   // OccupancySensor
   ////////////////////////////////////////////////////////////////   
-  else if (config.accessory == 'S7_OccupancySensor'){
+  else if (config.accessory == 'PLC_OccupancySensor'){
     this.service = new Service.OccupancySensor(this.name);
     this.accessory.addService(this.service);
 
@@ -419,7 +418,7 @@ function GenericS7(platform, config) {
   ////////////////////////////////////////////////////////////////
   // MotionSensor
   ////////////////////////////////////////////////////////////////   
-  else if (config.accessory == 'S7_MotionSensor'){
+  else if (config.accessory == 'PLC_MotionSensor'){
     this.service = new Service.OccupancySensor(this.name);
     this.accessory.addService(this.service);
 
@@ -433,7 +432,7 @@ function GenericS7(platform, config) {
   ////////////////////////////////////////////////////////////////
   // Faucet
   ////////////////////////////////////////////////////////////////   
-  else if (config.accessory == 'S7_Faucet'){
+  else if (config.accessory == 'PLC_Faucet'){
     this.service =  new Service.Faucet(this.name);
     this.accessory.addService(this.service);
 
@@ -465,9 +464,9 @@ function GenericS7(platform, config) {
     }
   }  
   ////////////////////////////////////////////////////////////////
-  // S7_SecuritySystem
+  // SecuritySystem
   ////////////////////////////////////////////////////////////////   
-  else if (config.accessory == 'S7_SecuritySystem'){
+  else if (config.accessory == 'PLC_SecuritySystem'){
     this.service = new Service.SecuritySystem(this.name);
     this.accessory.addService(this.service);
 
@@ -492,9 +491,9 @@ function GenericS7(platform, config) {
       )}.bind(this));        
   }  
   ////////////////////////////////////////////////////////////////
-  // S7_Valve
+  // Valve
   ////////////////////////////////////////////////////////////////   
-  else if (config.accessory == 'S7_Valve'){
+  else if (config.accessory == 'PLC_Valve'){
     this.service = new Service.Valve(this.name);
     this.accessory.addService(this.service);
 
@@ -591,10 +590,10 @@ function GenericS7(platform, config) {
     }      
   }    
   ////////////////////////////////////////////////////////////////
-  // S7_StatelessProgrammableSwitch
+  // StatelessProgrammableSwitch
   ////////////////////////////////////////////////////////////////   
   /*
-  else if (config.accessory == 'S7_StatelessProgrammableSwitch'){
+  else if (config.accessory == 'PLC_StatelessProgrammableSwitch'){
     this.service = new Service.StatelessProgrammableSwitch(this.name);
     this.accessory.addService(this.service);
 
@@ -626,7 +625,7 @@ function GenericS7(platform, config) {
 
 }
 
-GenericS7.prototype = {
+GenericPLCAccessory.prototype = {
 
   getServices: function() {
     return [this.accessory.getService(Service.AccessoryInformation), this.service];

--- a/index.js
+++ b/index.js
@@ -174,6 +174,42 @@ function GenericS7(platform, config) {
     }
   }
 
+
+  ////////////////////////////////////////////////////////////////
+  // Switch
+  ////////////////////////////////////////////////////////////////    
+  else if (config.accessory == 'S7_Switch') {   
+    this.service =  new Service.Switch(this.name);
+    this.accessory.addService(this.service);
+
+    if ('set_Off' in config) {      
+      this.service.getCharacteristic(Characteristic.On)
+        .on('get', function(callback) {this.getBit(callback, 
+          config.db, 
+          Math.floor(config.get_On), Math.floor((config.get_On*10)%10),
+          'get On'
+        )}.bind(this))
+        .on('set', function(powerOn, callback) { this.setOnOffBit(powerOn, callback, 
+          config.db, 
+          Math.floor(config.set_On), Math.floor((config.set_On*10)%10),
+          Math.floor(config.set_Off), Math.floor((config.set_Off*10)%10),
+          'set On'
+        )}.bind(this));
+    } else {
+      this.service.getCharacteristic(Characteristic.On)
+        .on('get', function(callback) {this.getBit(callback, 
+          config.db, 
+          Math.floor(config.get_On), Math.floor((config.get_On*10)%10),
+          'get On'
+        )}.bind(this))
+        .on('set', function(powerOn, callback) { this.setBit(powerOn, callback, 
+          config.db, 
+          Math.floor(config.set_On), Math.floor((config.set_On*10)%10),
+          'set On'
+        )}.bind(this));
+    }
+  }
+
   ////////////////////////////////////////////////////////////////
   // TemperatureSensor
   //////////////////////////////////////////////////////////////// 
@@ -343,12 +379,12 @@ function GenericS7(platform, config) {
         )}.bind(this));
     }
     else {
-        this.service.getCharacteristic(Characteristic.PositionState)
-      .on('get', function(callback) {this.getDummy(callback,
+      this.service.getCharacteristic(Characteristic.PositionState)
+        .on('get', function(callback) {this.getDummy(callback,
         2,
         'get PositionState'
         )}.bind(this));
-    }
+        }
       
     if ('set_HoldPosition' in config) {
     this.service.getCharacteristic(Characteristic.HoldPosition)
@@ -426,13 +462,158 @@ function GenericS7(platform, config) {
           'set Active'
         )}.bind(this));
     }
-  }
+  }  
+  ////////////////////////////////////////////////////////////////
+  // S7_SecuritySystem
+  ////////////////////////////////////////////////////////////////   
+  else if (config.accessory == 'S7_SecuritySystem'){
+    this.service = new Service.SecuritySystem(this.name);
+    this.accessory.addService(this.service);
+
+    this.service.getCharacteristic(Characteristic.SecuritySystemCurrentState)
+      .on('get', function(callback) {this.getByte(callback, 
+        config.db, 
+        config.get_SecuritySystemCurrentState,
+        "get SecuritySystemCurrentState"
+      )}.bind(this))    
+
+      this.service.getCharacteristic(Characteristic.SecuritySystemTargetState)
+      .on('get', function(callback) {this.getByte(callback, 
+        config.db, 
+        config.get_SecuritySystemTargetState,
+        "get SecuritySystemTargetState"
+      )}.bind(this))  
+      .on('set', function(value, callback) {this.setByte(value, callback, 
+        config.db, 
+        config.set_SecuritySystemTargetState,
+        "set SecuritySystemTargetState"
+      )}.bind(this));        
+  }  
+  ////////////////////////////////////////////////////////////////
+  // S7_Valve
+  ////////////////////////////////////////////////////////////////   
+  else if (config.accessory == 'S7_Valve'){
+    this.service = new Service.Valve(this.name);
+    this.accessory.addService(this.service);
+
+    if ('set_Deactive' in config) {      
+      this.service.getCharacteristic(Characteristic.Active)
+        .on('get', function(callback) {this.getBit(callback, 
+          config.db, 
+          Math.floor(config.get_Active), Math.floor((config.get_Active*10)%10),
+          'get Active'
+        )}.bind(this))
+        .on('set', function(powerOn, callback) { this.setOnOffBit(powerOn, callback, 
+          config.db, 
+          Math.floor(config.set_Active), Math.floor((config.set_Active*10)%10),
+          Math.floor(config.set_Deactive), Math.floor((config.set_Deactive*10)%10),
+          'set Active'
+        )}.bind(this));
+    } else {
+      this.service.getCharacteristic(Characteristic.Active)
+        .on('get', function(callback) {this.getBit(callback, 
+          config.db, 
+          Math.floor(config.get_Active), Math.floor((config.get_Active*10)%10),
+          'get Active'
+        )}.bind(this))
+        .on('set', function(powerOn, callback) { this.setBit(powerOn, callback, 
+          config.db, 
+          Math.floor(config.set_Active), Math.floor((config.set_Active*10)%10),
+          'set Active'
+        )}.bind(this));
+    }
+
+    if ('ValveType' in config) {   
+      this.service.getCharacteristic(Characteristic.ValveType)
+        .on('get', function(callback) {this.getDummy(callback,
+          ValveType,
+        'get ValveType'
+        )}.bind(this));
+    }
+    
+
+    if ('InUse' in config) {   
+      this.service.getCharacteristic(Characteristic.InUse)
+        .on('get', function(callback) {this.getDummy(callback,
+          config.InUse,
+        'get InUse'
+        )}.bind(this));        
+    }
+
+    
+
+    if ('get_InUse' in config) {   
+/*
+      setInterval(function() {this.getBit( 
+        function(err, value){this.service.getCharacteristic(Characteristic.InUse).updateValue(value) }.bind(this),
+        config.db, 
+        Math.floor(config.get_InUse), Math.floor((config.get_InUse*10)%10),
+        'poll InUse'
+        )}.bind(this),5000);
+*/
+
+      this.service.getCharacteristic(Characteristic.InUse)
+      .on('get', function(callback) {this.getBit(callback, 
+        config.db, 
+        Math.floor(config.get_InUse), Math.floor((config.get_InUse*10)%10),
+        'get InUse'
+      )}.bind(this))
+    }
+
+
+
+    if ('get_RemainingDuration' in config) {   
+      this.service.getCharacteristic(Characteristic.RemainingDuration)
+        .on('get', function(callback) {this.getDInt(callback, 
+          config.db, 
+          config.get_RemainingDuration,
+          "get RemainingDuration",
+          this.s7time2int
+        )}.bind(this))    
+
+        this.service.getCharacteristic(Characteristic.SetDuration)
+        .on('get', function(callback) {this.getDInt(callback, 
+          config.db, 
+          config.get_SetDuration,
+          "get SetDuration",
+          this.s7time2int
+        )}.bind(this))  
+        .on('set', function(value, callback) {this.setDInt(value, callback, 
+          config.db, 
+          config.set_SetDuration,
+          "set SetDuration2",
+          this.int27time
+        )}.bind(this));  
+    }      
+  }    
+  ////////////////////////////////////////////////////////////////
+  // S7_StatelessProgrammableSwitch
+  ////////////////////////////////////////////////////////////////   
+  /*
+  else if (config.accessory == 'S7_StatelessProgrammableSwitch'){
+    this.service = new Service.StatelessProgrammableSwitch(this.name);
+    this.accessory.addService(this.service);
+
+    this.service.getCharacteristic(Characteristic.ProgrammableSwitchEvent)
+      .on('get', function(callback) {this.getByte(callback, 
+        config.db, 
+        config.get_ProgrammableSwitchEvent,
+        "get ProgrammableSwitchEvent"
+      )}.bind(this));
+
+      this.service.getCharacteristic(Characteristic.ServiceLabelIndex)
+      .on('get', function(callback) {this.getDummy(callback, 
+        1,
+        "get ServiceLabelIndex"
+      )}.bind(this))
+  }    
+      */      
   else {
     this.log("Accessory "+ config.accessory + " is not defined.")
   }
       
   this.accessory.getService(Service.AccessoryInformation)
-  .setCharacteristic(Characteristic.Manufacturer, ('manufacturer' in config) ? config.manufacturer : 'S7-PLC')
+  .setCharacteristic(Characteristic.Manufacturer, ('manufacturer' in config) ? config.manufacturer : 'homebridge-plc')
   .setCharacteristic(Characteristic.Model, config.accessory)
   .setCharacteristic(Characteristic.SerialNumber, uuid)
   .setCharacteristic(Characteristic.FirmwareRevision, '0.0.1'); 
@@ -453,6 +634,21 @@ GenericS7.prototype = {
   
   plain_0_100: function(value) {
     return value;
+  },
+
+  s7time2int: function(value){
+    var val = Math.ceil(value/1000);
+    if (val > 3600) {
+      val = 3600;
+    }
+    if (val < 0) {
+      val = 0;
+    }
+    return val;
+  },
+
+  int27time: function(value){
+    return (value * 1000);
   },
 
   //////////////////////////////////////////////////////////////////////////////
@@ -496,12 +692,11 @@ GenericS7.prototype = {
     if (this.platform.S7ClientConnect()) {
 
       this.buf[0] = 1;
-      // Write single Bit to DB asynchonousely...
       S7Client.WriteArea(S7Client.S7AreaDB, db, ((offset*8) + bit), 1, S7Client.S7WLBit, this.buf, function(err) {
         if(err) {
           log.error(logprefix, "WriteArea failed #" + String(err) + " - " + S7Client.ErrorText(err));
           S7Client.Disconnect();
-          callback(err);
+          callback(new Error('PLC error'));
         }
         else {
           log.debug(logprefix , String(value));
@@ -524,12 +719,11 @@ GenericS7.prototype = {
     //ensure PLC connection
     if (this.platform.S7ClientConnect()) {
       this.buf[0] = value ? 1 : 0;
-      // Write single Bit to DB asynchonousely...
       S7Client.WriteArea(S7Client.S7AreaDB, db, ((offset*8) + bit), 1, S7Client.S7WLBit, this.buf, function(err) {
         if(err) {
           log.error(logprefix, "WriteArea failed #" + String(err) + " - " + S7Client.ErrorText(err));
           S7Client.Disconnect();
-          callback(err);
+          callback(new Error('PLC error'));
         }
         else {
           log.debug(logprefix , String(value));
@@ -553,7 +747,6 @@ GenericS7.prototype = {
     this.platform.S7ClientConnect();
       
     if (this.platform.S7ClientConnect()) {
-      // Read one bit from PLC DB asynchonousely...
       S7Client.ReadArea(S7Client.S7AreaDB, db, ((offset*8) + bit), 1, S7Client.S7WLBit, function(err, res) {
         if(err) {
           log.error(logprefix, "ReadArea failed #" + String(err) + " - " + S7Client.ErrorText(err));
@@ -590,12 +783,11 @@ GenericS7.prototype = {
     //ensure PLC connection    
     if (this.platform.S7ClientConnect()) {
         buf.writeFloatBE(valuePLC, 0);
-        // Write one real from DB asynchonousely...
         S7Client.WriteArea(S7Client.S7AreaDB, db, offset, 1, S7Client.S7WLReal, buf, function(err) {
           if(err) {
             log.error(logprefix, "WriteArea failed #" + String(err) + " - " + S7Client.ErrorText(err));
             S7Client.Disconnect();
-            callback(err);
+            callback(new Error('PLC error'));
           }
           else {              
             if (typeof(valueMod) != "undefined")
@@ -622,14 +814,12 @@ GenericS7.prototype = {
     var name = this.name;
     var value = 0;
     //ensure PLC connection
-    if (this.platform.S7ClientConnect()) {
-        // Write one real from DB asynchonousely...
-        
+    if (this.platform.S7ClientConnect()) {        
         S7Client.ReadArea(S7Client.S7AreaDB, db, offset, 1, S7Client.S7WLReal, function(err, res) {
           if(err) {
             log.error(logprefix, "ReadArea failed #" + String(err) + " - " + S7Client.ErrorText(err));
             S7Client.Disconnect();
-            callback(err);
+            callback(new Error('PLC error'));
           }
           else {              
             valuePLC = res.readFloatBE(0);
@@ -671,12 +861,11 @@ GenericS7.prototype = {
     //ensure PLC connection    
     if (this.platform.S7ClientConnect()) {
         buf[0] = valuePLC;
-        // Write one real from DB asynchonousely...
         S7Client.WriteArea(S7Client.S7AreaDB, db, offset, 1, S7Client.S7WLByte, buf, function(err) {
           if(err) {
             log.error(logprefix, "WriteArea failed #" + String(err) + " - " + S7Client.ErrorText(err));
             S7Client.Disconnect();
-            callback(err);
+            callback(new Error('PLC error'));
           }
           else {              
             if (typeof(valueMod) != "undefined")
@@ -703,14 +892,12 @@ GenericS7.prototype = {
     var name = this.name;
     var value = 0;
     //ensure PLC connection    
-    if (this.platform.S7ClientConnect()) {
-        // Write one real from DB asynchonousely...
-        
+    if (this.platform.S7ClientConnect()) {      
         S7Client.ReadArea(S7Client.S7AreaDB, db, offset, 1, S7Client.S7WLByte, function(err, res) {
           if(err) {
             log.error(logprefix, "ReadArea failed #" + String(err) + " - " + S7Client.ErrorText(err));
             S7Client.Disconnect();
-            callback(err);
+            callback(new Error('PLC error'));
           }
           else {              
             valuePLC = res[0];
@@ -753,12 +940,11 @@ GenericS7.prototype = {
     //ensure PLC connection
     if (this.platform.S7ClientConnect()) {
         buf.writeInt16BE(valuePLC, 0);
-        // Write one real from DB asynchonousely...
         S7Client.WriteArea(S7Client.S7AreaDB, db, offset, 1, S7Client.S7WLWord, buf, function(err) {
           if(err) {
             log.error(logprefix, "WriteArea failed #" + String(err) + " - " + S7Client.ErrorText(err));
             S7Client.Disconnect();
-            callback(err);
+            callback(new Error('PLC error'));
           }
           else {              
             if (typeof(valueMod) != "undefined")
@@ -786,17 +972,95 @@ GenericS7.prototype = {
     var value = 0;
     var valuePLC = 0;
     //ensure PLC connection
-    if (this.platform.S7ClientConnect()) {
-        // Write one real from DB asynchonousely...
-        
+    if (this.platform.S7ClientConnect()) {       
         S7Client.ReadArea(S7Client.S7AreaDB, db, offset, 1, S7Client.S7WLWord, function(err, res) {
           if(err) {
             log.error(logprefix, "ReadArea failed #" + String(err) + " - " + S7Client.ErrorText(err));
             S7Client.Disconnect();
-            callback(err);
+            callback(new Error('PLC error'));
           }
           else {              
             valuePLC = res.readInt16BE(0);
+            if (typeof(valueMod) != "undefined")
+            {
+              value = valueMod(valuePLC);
+              log.debug(logprefix , String(value) + "<-" + String(valuePLC));
+            }            
+            else
+            {
+              value = valuePLC;
+              log.debug(logprefix , String(value));
+            }            
+            callback(null, value);
+          }
+        });
+    }
+    else {
+        callback(new Error('PLC not connected'));
+    }
+  },
+
+
+
+  //////////////////////////////////////////////////////////////////////////////
+  // DInt
+  //////////////////////////////////////////////////////////////////////////////
+  setDInt: function(value, callback, db, offset, characteristic, valueMod) {
+    var logprefix = "[" + this.name + "] " + characteristic + ": %s (setDInt DB" + db + "DBD"+ offset + ")";    
+    var S7Client = this.platform.S7Client;
+    var log = this.log;
+    var name = this.name;
+    var buf = this.buf
+    var valuePLC = value;
+
+    if (typeof(valueMod) != "undefined")
+    {
+      valuePLC = valueMod(value);
+    }
+    //ensure PLC connection
+    if (this.platform.S7ClientConnect()) {
+        buf.writeInt32BE(valuePLC, 0);
+        S7Client.WriteArea(S7Client.S7AreaDB, db, offset, 1, S7Client.S7WLDWord, buf, function(err) {
+          if(err) {
+            log.error(logprefix, "WriteArea failed #" + String(err) + " - " + S7Client.ErrorText(err));
+            S7Client.Disconnect();
+            callback(new Error('PLC error'));
+          }
+          else {              
+            if (typeof(valueMod) != "undefined")
+            {
+              log.debug(logprefix , String(value) + "->" + String(valuePLC));
+            }            
+            else
+            {
+              log.debug(logprefix , String(value));
+            }  
+            callback(null);
+          }
+        });
+    }
+    else {
+        callback(new Error('PLC not connected'));
+    }
+  },
+    
+  getDInt: function(callback, db, offset, characteristic, valueMod) {
+    var logprefix = "[" + this.name + "] " + characteristic + ": %s (getDInt DB" + db + "DBD"+ offset + ")";    
+    var S7Client = this.platform.S7Client;
+    var log = this.log;
+    var name = this.name;
+    var value = 0;
+    var valuePLC = 0;
+    //ensure PLC connection
+    if (this.platform.S7ClientConnect()) {
+        S7Client.ReadArea(S7Client.S7AreaDB, db, offset, 1, S7Client.S7WLDWord, function(err, res) {
+          if(err) {
+            log.error(logprefix, "ReadArea failed #" + String(err) + " - " + S7Client.ErrorText(err));
+            S7Client.Disconnect();
+            callback(new Error('PLC error'));
+          }
+          else {              
+            valuePLC = res.readInt32BE(0);
             if (typeof(valueMod) != "undefined")
             {
               value = valueMod(valuePLC);

--- a/index.js
+++ b/index.js
@@ -73,10 +73,6 @@ PLC_Platform.prototype = {
 }
 
 
-
-
-
-
 function GenericPLCAccessory(platform, config) {
   this.platform = platform;
   this.log = platform.log;
@@ -87,7 +83,7 @@ function GenericPLCAccessory(platform, config) {
   ////////////////////////////////////////////////////////////////
   // Lightbulb
   ////////////////////////////////////////////////////////////////
-  if (config.accessory == 'PLC_PLC_LightBulb') {   
+  if (config.accessory == 'PLC_LightBulb') {   
     this.service =  new Service.Lightbulb(this.name);
     this.accessory.addService(this.service);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-plc",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Homebridge plugin for Siemens Step7 and compatible PLCs. (https://github.com/homebridge)",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-plc",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Homebridge plugin for Siemens Step7 and compatible PLCs. (https://github.com/homebridge)",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-plc",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Homebridge plugin for Siemens Step7 and compatible PLCs. (https://github.com/homebridge)",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
### Added #3 
- Platform `PLC`: Polling mode that enables background task poll accessories. New configuration `enablePolling`
- Accessory: `PLC_WindowCovering`: Adaptive polling when moving blinds. New configuration `adaptivePolling` and `pollInterval`
- Accessory: `PLC_SecuritySystem`: Polling to detect changes. New configuration `enablePolling` and `pollInterval`
 
### Fix
- platformname
