### PR TITLE
Fix for  remotely controllable windows, add support for door, switch, lock mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+*mind the rename from S7 to PLC from version 1.0.3*
+
+## [1.0.6] - 2020-10-12
+### Added
+- Accessory `PLC_StatelessProgrammableSwitch` is now functional
+- Accessory `PLC_Door` added
+- Accessory `PLC_GarageDoorOpener` added (experimental state)
+- Accessory `PLC_LockMechanism` added (experimental state)
+- New configuration option `mapGet` for `PLC_WindowCovering`, `PLC_Window` and `PLC_Door` to map custom values 
+
+### Fixed 
+- `PLC_WindowCovering`, `PLC_Window` and `PLC_Door` when target settings are not defined (not electric movable). Writes are ignored instead current value is pushed as target value as get after a set operation
+
 
 ## [1.0.5] - 2020-10-11
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-plc",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Homebridge plugin for Siemens Step7 and compatible PLCs. (https://github.com/homebridge)",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
### Added
- Accessory `PLC_StatelessProgrammableSwitch` is now functional
- Accessory `PLC_Door` added
- Accessory `PLC_GarageDoorOpener` added (experimental state)
- Accessory `PLC_LockMechanism` added (experimental state)
- New configuration option `mapGet` for `PLC_WindowCovering`, `PLC_Window` and `PLC_Door` to map custom values 

### Fixed 
- `PLC_WindowCovering`, `PLC_Window` and `PLC_Door` when target settings are not defined (not electric movable). Writes are ignored instead current value is pushed as target value as get after a set operation