### PR TITLE
Support of push from PLC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.10] - 2020-10-21
 ### Added
 - Support to push updated variables from the PLC to the homebridge-plc plug in by a http request
+- Poll support for all supported accessories. (Please inform me if one is not working as expected)
 
 ### Changed
 - Accessory `PLC_WindowCovering`, `PLC_Window` and `PLC_Door` need to define new option `forceCurrentPosition` to maintain current behaviour! 
+
+### Fixed
+- Accessory `PLC_GarageDoorOpener` add missing `get_LockCurrentState` 
 
 
 ## [1.0.9] - 2020-10-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 *mind the rename from S7 to PLC from version 1.0.3*
+## [1.0.10] - 2020-10-21
+### Added
+- Support to push updated variables from the PLC to the homebridge-plc plug in by a http request
+
+### Changed
+- Accessory `PLC_WindowCovering`, `PLC_Window` and `PLC_Door` need to define new option `forceCurrentPosition` to maintain current behaviour! 
+
 
 ## [1.0.9] - 2020-10-21
 ### Added
-
 - Accessory: `PLC_OccupancySensor`: Add polling to detect changes. New configuration `enablePolling` and `pollInterval`
 - Accessory: `PLC_MotionSensor`: Add polling to detect changes. New configuration `enablePolling` and `pollInterval`
 - Accessory: `PLC_ContactSensor` added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-*mind the rename from S7 to PLC from version 1.0.3*
-## [1.0.10] - 2020-10-21
+## [1.0.10] - 2020-10-26
 ### Added
-- Support to push updated variables from the PLC to the homebridge-plc plug in by a http request
+- **Push support** from the PLC to the homebridge-plc plug in by a http request
 - Poll support for all supported accessories. (Please inform me if one is not working as expected)
 
 ### Changed
@@ -15,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Accessory `PLC_GarageDoorOpener` add missing `get_LockCurrentState` 
-
 
 ## [1.0.9] - 2020-10-21
 ### Added

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ normal humidity sensor
 - `name`: unique name of the accessory 
 - `manufacturer`: (optional) description
 - `db`: s7 data base number e.g. `4` for `DB4`
-- `CurrentRelativeHumidity`: offset to get current humidity S7 type `Real` e.g. `55` for `DB4DBD55` 
+- `get_CurrentRelativeHumidity`: offset to get current humidity S7 type `Real` e.g. `55` for `DB4DBD55` 
 - humidity range (optional)
   - `minValue` default value: 0
   - `maxValue` default value: 100
@@ -145,8 +145,8 @@ shutters or blinds as well sensors for windows and doors
 - `pollInterval` (optional) poll interval in seconds. Default value is `10` seconds.
 - `get_CurrentPosition`: offset to get current position S7 type `Byte` e.g. `0` for `DB4DBB0`  
 - if one of the (optional) target position settings need specified all are needed. If not specified it os not movable ans sticks to current position.
-  - `get_TargetPosition`: (optional) offset to get target position S7 type `Byte` e.g. `1` for `DB4DBB1`  
-  - `set_TargetPosition`: (optional) offset to set current position S7 type `Byte` e.g. `2` for `DB4DBB2` (can have same value as set_TargetPosition)
+  - `get_TargetPosition`: (optional) offset to get target position S7 type `Byte` e.g. `1` for `DB4DBB1`  (can have same value as set_TargetPosition)
+  - `set_TargetPosition`: (optional) offset to set current position S7 type `Byte` e.g. `2` for `DB4DBB2` (can have same value as get_TargetPosition)
 - `get_PositionState`: (optional) offset to current movement state if not defined fixed `2`is returned S7 type `Byte` e.g. `3` for `DB4DBB3`    
     - `0`: down
     - `1`: up

--- a/README.md
+++ b/README.md
@@ -529,3 +529,18 @@ Example for bool values when trigger from browser
 Example for byte values when trigger from browser 
   
   http://homebridgeIp:8080/?push&db=2&offset=3&value=255
+  
+
+# Test & Release
+
+## Local test
+The easiest is to open the terminal from homebridge delete the `index.js` file of this plugin, open nano and past in the new content.
+Afterwards the Homebridge can be restarted.
+The delete and open of hte index.js file can be done by the following command line.
+
+`rm node_modules/homebridge-plc/index.js && nano node_modules/homebridge-plc/index.js`
+
+
+## Publish npm package
+
+`npm publish --access public`

--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ shutters or blinds as well sensors for windows and doors
 - `db`: s7 data base number e.g. `4` for `DB4`
 - `invert`: (optional) set to `true` to inverts the meanings of the values from `0:closed 100:open` to `100:closed 0:open`
 - `mapGet`: (optional) define mapping array for get position. The PLC value is used as index into the table. e.g. `[0, 25, 100]` which maps the PLC value `0->0 1->25 2->100` this this is useful e.g. for window open state.
-- `adaptivePolling`:  (optional) hen set to `true` the current position will be polled until target position is reached. Polling starts with set target position from home app. This will show the shutter as opening... or closing... in the home app. Otherwise the new target position is directly pushed as new current position.
+- `adaptivePolling`:  (optional) when set to `true` the current position will be polled until target position is reached. Polling starts with set target position from home app. This allows to show the shutter as opening... or closing... in the home app during movement. 
+- `forceCurrentPosition` (optional) when set to `true` the new position of a `set_TargetPosition` is directly pushed as new current position. This shows in the in the app as directly reached the target position. This is recommended when not using `adaptivePolling` or pushing the new values.
 - `pollInterval` (optional) poll interval in seconds. Default value is `10` seconds.
 - `get_CurrentPosition`: offset to get current position S7 type `Byte` e.g. `0` for `DB4DBB0`  
 - if one of the (optional) target position settings need specified all are needed. If not specified it os not movable ans sticks to current position.
@@ -288,6 +289,11 @@ Lock mechanism (not yet clear how to use changes are welcome)
   - `set_TargetDoorState`:  offset to write target state current state S7 type `Byte` e.g. `3` for `DB4DBB3` 
     - `0`: open
     - `1`: closed
+  - `get_LockCurrentState`: offset to read current state current state S7 type `Byte` e.g. `3` for `DB4DBB3` 
+    - `0`: unsecured
+    - `1`: secured
+    - `2`: jammed 
+    - `3`: unknown
   - `get_LockTargetState`: offset to read target state current state S7 type `Byte` e.g. `3` for `DB4DBB3` 
     - `0`: unsecured
     - `1`: secured

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ SIEMENS S7 PLC plugin for [Homebridge](https://homebridge.io)
   - and compatible PLCs e.g. Yaskawa or VIPA
 - Tested with S7-300 compatible PLC
 - Implementation is based on documentation of the [Homebridge API](https://developers.homebridge.io) 
+- Supports polling from homebridge-plc plugin to PLC
+- Supports push from PLC to homebridge-plc plugin
 
 
 # Installation
@@ -38,8 +40,9 @@ Parameters:
   - `rack`: the rack number of the PLC typically 0
   - `slot`: the slot number of the PLC for S7 300/400 typically `2`, for 1200/1500 typically `1` 
   - `enablePolling`: when set to `true` a background task is executed every second enable polling for the accessories
+  - `enablePush`: when set to `true` a the configured `port` is opened to push updates of values form plc to the plugin 
+  - `port`: port for http requests default `8080`
   
-
 ## Accessories
 - In the platform, you can declare different types of accessories currently supported:
 ### LightBulb as `PLC_LightBulb`
@@ -306,7 +309,7 @@ Note: The example is just an example it contains also some optional settings
             "ip": "10.10.10.32",
             "rack": 0,
             "slot": 2,
-            "enablePolling": true;
+            "enablePolling": true,
             "accessories": [
                 {
                     "accessory": "PLC_LightBulb",
@@ -483,3 +486,35 @@ Note: The example is just an example it contains also some optional settings
         }
         ]
     }
+
+# Update of values
+The home app does not regularly poll for updates of values. Only when switching rooms or close/open the app the actual values are requested.
+This behaviour is even the case when a AppleTV or HomePod is configured as control center.
+There are three possible ways to workaround this.
+
+1. That's ok for your
+2. You enable the polling mode 
+3. You enable the push mode and instrument your PLC code to send the values
+
+## Poll values form PLC
+To enable this you have to set `"enablePolling": true;` platform level and on each individual acessory with individual interval in seconds.
+    `"enablePolling": true, "pollInterval": 30,`
+    
+    
+## Push values from PLC
+
+It possible to send updates of values directly from the plc to the homebridge-plc plugin. This is especially useful when you want notifications form your home app about open/close of doors or just a faster response e.g. with PLC_StatelessProgrammableSwitch.
+To enable this you have to set `"enablePolling": true,` platform level and optional the `port`. 
+
+The push is done by an http request to the configured port. To to have no additional configuration on the PLC the interface only reqires the only the data base number `db`, the offset within the db `offset` and the new data as `value`. All information are submitted within the URL. 
+
+The Request has to be done as HTTP `PUT` or `GET` operation. There will be no logging when doing a `PUT` operation while there will be detailed ouput when duing a `GET` operation. This in especially inteded for testing with the browser as the browser performs a `GET` operation per default.
+
+### Format
+Example for float values when trigger from browser
+  
+  http://homebridgeIp:8080/?db=3&offset=22&value=12.5
+  
+Example for bool values when trigger from browser 
+  
+  http://homebridgeIp:8080/?db=5&offset=5.1&value=1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-plc",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Homebridge plugin for Siemens Step7 and compatible PLCs. (https://github.com/homebridge)",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## [1.0.10] - 2020-10-26
### Added
- **Push support** from the PLC to the homebridge-plc plug in by a http request
- Poll support for all supported accessories. (Please inform me if one is not working as expected)

### Changed
- Accessory `PLC_WindowCovering`, `PLC_Window` and `PLC_Door` need to define new option `forceCurrentPosition` to maintain current behaviour! 

### Fixed
- Accessory `PLC_GarageDoorOpener` add missing `get_LockCurrentState` 