### PR TITLE
V1.0.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.0.22] - 2020-12-30
+## [1.0.22] - 2021-01-01
 
 ### Changed
 - changed `defaultPort` from `8080` to `8888` avoid conflicts with Homebridge UI which has 8080 as default port. The port is used when using `enablePush` or `enableControl` is set. **(check your config)**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.0.22] - 2021-01-01
 
 ### Changed
-- changed `defaultPort` from `8080` to `8888` avoid conflicts with Homebridge UI which has 8080 as default port. The port is used when using `enablePush` or `enableControl` is set. **(check your config)**
+- changed **default value** for parameter `port` from `8080` to `8888`. This was done to avoid conflicts with Homebridge UI which has 8080 as default port. The port is used when using `enablePush` or `enableControl` is set. **(check your config)**
 
 ### Added
 - add option `defaultPollInterval` on platform level

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,21 @@
 # Changelog
 
+## [1.0.22] - 2020-12-30
+
+### Changed
+- changed `defaultPort` from `8080` to `8888` avoid conflicts with Homebridge UI which has 8080 as default port. The port is used when using `enablePush` or `enableControl` is set. **(check your config)**
+
+### Added
+- add option `defaultPollInterval` on platform level
+- add option `distributePolling` on platform level
+
 ## [1.0.21] - 2020-12-29
 
 ### Added
 - control support for `PLC_Thermostat`
 
 ### Fixed
-- control handling for `PLC_Windows`, `PLC_WindowCovering` and `PLC_Door` 
+- control handling for `PLC_Windows`, `PLC_WindowCovering` and `PLC_Door`
 - control handling for `PLC_Faucet` and `PLC_Valve`
 
 ### Changed
@@ -18,7 +27,7 @@
 
 ### Added
 - add `PLC_SmokeSensor`
-  
+
 ## [1.0.19] - 2020-11-19
 
 ### Added
@@ -34,7 +43,7 @@
 ### Changed
 - added option `forceDoorState` for `PLC_GarageDoorOpener`
 - Home app seems does not to use the lock for `PLC_GarageDoorOpener`. Remove `get_LockCurrentState`, `get_LockTargetState` and `set_LockTargetState`
-  
+
 ## [1.0.17] - 2020-11-14
 
 ### Changed
@@ -42,7 +51,7 @@
 
 ### Fixed
 - Fixed `PLC_LightBulb` brightness to be `Byte` value as documented. In fact is was a `Real` please change in PLC if you already use it.
-  
+
 ## [1.0.16] - 2020-11-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Parameters:
 - `slot`: the slot number of the PLC for S7 300/400 typically `2`, for 1200/1500 typically `1`
 - `enablePolling`: **(optional)** when set to `true` a background task is executed every second enable polling for the accessories
 - `defaultPollInterval` **(optional)** default polling interval for all accessories in seconds. Default value is `10` seconds.
-- `distributePolling` **(optional)** when set to `true` the polling of the accessories does not start at the same time.
+- `distributePolling` **(optional)** when set to `true` the polling of the accessories does not start at the same time. In order to distribute the PLC load for the queries.
 - `enablePush`: **(optional)** when set to `true` a the configured `port` is opened to push updates of values form plc to the plugin
 - `enableControl`: **(optional)** when set to `true` a the configured `port` is opened to control accessories by http request
 - `port`: **(optional)** port for http requests default `8888`
@@ -106,9 +106,9 @@ outlet possible to show also as ventilator or light
 - `pollInterval` **(optional)** poll interval in seconds. Default value see platform definition.
 - `get_On`: **(push support)** offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`
 - Single Bit for on/off:
-	- `set_On`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC e.g. `55.0` for `DB4DBX55.0` could be same as get_On
+	- `set_On`: **(control support)** offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC e.g. `55.0` for `DB4DBX55.0` could be same as get_On
 - Separate Bits for on/off:
-	- `set_On`: offset and bit set to 1 when switching on S7 type `Bool` **PLC has to set to 0** e.g. `55.1` for `DB4DBX55.1`
+	- `set_On`: **(control support)** offset and bit set to 1 when switching on S7 type `Bool` **PLC has to set to 0** e.g. `55.1` for `DB4DBX55.1`
 	- `set_Off`: offset and bit set to 1 when switching off S7 type `Bool` **PLC has to set to 0** e.g. `55.2` for `DB4DBX55.2`
 
 ### <a name='PLC_Switch'></a>Switch as `PLC_Switch`
@@ -122,9 +122,9 @@ outlet possible to show also as ventilator or light
 - `pollInterval` **(optional)** poll interval in seconds. Default value see platform definition.
 - `get_On`: **(push support)** offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`
 - Single Bit for on/off:
-	- `set_On`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC e.g. `55.0` for `DB4DBX55.0` could be same as get_On
+	- `set_On`: **(control support)** offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC e.g. `55.0` for `DB4DBX55.0` could be same as get_On
 - Separate Bits for on/off:
-	- `set_On`: offset and bit set to 1 when switching on S7 type `Bool` **PLC has to set to 0** e.g. `55.1` for `DB4DBX55.1`
+	- `set_On`: **(control support)** offset and bit set to 1 when switching on S7 type `Bool` **PLC has to set to 0** e.g. `55.1` for `DB4DBX55.1`
 	- `set_Off`: offset and bit set to 1 when switching off S7 type `Bool` **PLC has to set to 0** e.g. `55.2` for `DB4DBX55.2`
 
 ### <a name='PLC_TemperatureSensor'></a>Temperature Sensor as `PLC_TemperatureSensor`
@@ -206,12 +206,12 @@ motor driven blinds, windows and doors. Supports also manual driven blinds, wind
 - `get_CurrentPosition`: **(push support)** offset to get current position S7 type `Byte` e.g. `0` for `DB4DBB0`
 - if one of the **(optional)** target position settings need specified all are needed. If not specified it os not movable ans sticks to current position.
 	- `get_TargetPosition`: **(optional)** **(push support)** offset to get target position S7 type `Byte` e.g. `1` for `DB4DBB1` (can have same value as set_TargetPosition)
-	- `set_TargetPosition`: **(optional)** offset to set current position S7 type `Byte` e.g. `2` for `DB4DBB2` (can have same value as get_TargetPosition)
+	- `set_TargetPosition`: **(optional)** **(control support)** offset to set current position S7 type `Byte` e.g. `2` for `DB4DBB2` (can have same value as get_TargetPosition)
 - `get_PositionState`: **(optional)** **(push support)** offset to current movement state if not defined fixed `2`is returned S7 type `Byte` e.g. `3` for `DB4DBB3`
 	- `0`: down
 	- `1`: up
 	- `2`: stop
-- `set_HoldPosition`: **(optional)**: offset and bit set to 1 to stop movement. (Seems not to be used) when not defined writes will be ignoredS7 type `Bool` **PLC has to set to 0** e.g. `55.1` for `DB4DBX55.1`
+- `set_HoldPosition`: **(optional)** **(control support)** offset and bit set to 1 to stop movement. (Seems not to be used) when not defined writes will be ignoredS7 type `Bool` **PLC has to set to 0** e.g. `55.1` for `DB4DBX55.1`
 
 ### <a name='PLC_OccupancySensor'></a>Occupancy Sensor as `PLC_OccupancySensor`
 presence detection sensor

--- a/README.md
+++ b/README.md
@@ -61,10 +61,12 @@ Parameters:
 - `ip`: the IPv4 address of the PLC
 - `rack`: the rack number of the PLC typically 0
 - `slot`: the slot number of the PLC for S7 300/400 typically `2`, for 1200/1500 typically `1`
-- `enablePolling`: when set to `true` a background task is executed every second enable polling for the accessories
-- `enablePush`: when set to `true` a the configured `port` is opened to push updates of values form plc to the plugin
-- `enableControl`: when set to `true` a the configured `port` is opened to control accessories by http request
-- `port`: port for http requests default `8080`
+- `enablePolling`: **(optional)** when set to `true` a background task is executed every second enable polling for the accessories
+- `defaultPollInterval` **(optional)** default polling interval for all accessories in seconds. Default value is `10` seconds.
+- `distributePolling` **(optional)** when set to `true` the polling of the accessories does not start at the same time.
+- `enablePush`: **(optional)** when set to `true` a the configured `port` is opened to push updates of values form plc to the plugin
+- `enableControl`: **(optional)** when set to `true` a the configured `port` is opened to control accessories by http request
+- `port`: **(optional)** port for http requests default `8888`
 
 ## Accessories
 - In the platform, you can declare different types of accessories
@@ -79,7 +81,7 @@ normal light see also simple PLC example for [single bit](doc/ligtbulb_plc_examp
 - `manufacturer`: **(optional)** description
 - `db`: s7 data base number e.g. `4` for `DB4`
 - `enablePolling`: **(optional)** when set to `true` the current state will be polled. It is mandatory as well to enable polling mode on platform level.
-- `pollInterval` **(optional)** poll interval in seconds. Default value is `10` seconds.
+- `pollInterval` **(optional)** poll interval in seconds. Default value see platform definition.
 - `get_On`: **(push support)** offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`
 - Single Bit for on/off:
 	- `set_On`: **(control support)** offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC e.g. `55.0` for `DB4DBX55.0` could be same as get_On
@@ -101,7 +103,7 @@ outlet possible to show also as ventilator or light
 - `manufacturer`: **(optional)** description
 - `db`: s7 data base number e.g. `4` for `DB4`
 - `enablePolling`: **(optional)** when set to `true` the current state will be polled. It is mandatory as well to enable polling mode on platform level.
-- `pollInterval` **(optional)** poll interval in seconds. Default value is `10` seconds.
+- `pollInterval` **(optional)** poll interval in seconds. Default value see platform definition.
 - `get_On`: **(push support)** offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`
 - Single Bit for on/off:
 	- `set_On`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC e.g. `55.0` for `DB4DBX55.0` could be same as get_On
@@ -117,7 +119,7 @@ outlet possible to show also as ventilator or light
 - `manufacturer`: **(optional)** description
 - `db`: s7 data base number e.g. `4` for `DB4`
 - `enablePolling`: **(optional)** when set to `true` the current state will be polled. It is mandatory as well to enable polling mode on platform level.
-- `pollInterval` **(optional)** poll interval in seconds. Default value is `10` seconds.
+- `pollInterval` **(optional)** poll interval in seconds. Default value see platform definition.
 - `get_On`: **(push support)** offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`
 - Single Bit for on/off:
 	- `set_On`: offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC e.g. `55.0` for `DB4DBX55.0` could be same as get_On
@@ -133,7 +135,7 @@ normal temperature sensor
 - `manufacturer`: **(optional)** description
 - `db`: s7 data base number e.g. `4` for `DB4`
 - `enablePolling`: **(optional)** when set to `true` the current state will be polled. It is mandatory as well to enable polling mode on platform level.
-- `pollInterval` **(optional)** poll interval in seconds. Default value is `10` seconds.
+- `pollInterval` **(optional)** poll interval in seconds. Default value see platform definition.
 - `get_CurrentTemperature`: **(push support)** offset to get current temperature S7 type `Real` e.g. `55` for `DB4DBD55`
 - temperature range **(optional)**
 	- `minValue` default value: -50
@@ -148,7 +150,7 @@ normal humidity sensor
 - `manufacturer`: **(optional)** description
 - `db`: s7 data base number e.g. `4` for `DB4`
 - `enablePolling`: **(optional)** when set to `true` the current state will be polled. It is mandatory as well to enable polling mode on platform level.
-- `pollInterval` **(optional)** poll interval in seconds. Default value is `10` seconds.
+- `pollInterval` **(optional)** poll interval in seconds. Default value see platform definition.
 - `get_CurrentRelativeHumidity`: **(push support)** offset to get current humidity S7 type `Real` e.g. `55` for `DB4DBD55`
 - humidity range **(optional)**
 	- `minValue` default value: 0
@@ -164,7 +166,7 @@ temperature sensor and temperature regulation
 - `manufacturer`: **(optional)** description
 - `db`: s7 data base number e.g. `4` for `DB4`
 - `enablePolling`: **(optional)** when set to `true` the current state will be polled. It is mandatory as well to enable polling mode on platform level.
-- `pollInterval` **(optional)** poll interval in seconds. Default value is `10` seconds.
+- `pollInterval` **(optional)** poll interval in seconds. Default value see platform definition.
 - `get_CurrentTemperature`: offset to get current humidity S7 type `Real` e.g. `55` for `DB4DBD55`
 - S7 type `Byte` e.g. `56` for `DB4DBB56`
 - `get_CurrentTemperature`: **(push support)** offset to get current temperature S7 type `Real` e.g. `0` for `DB4DBD0`
@@ -200,7 +202,7 @@ motor driven blinds, windows and doors. Supports also manual driven blinds, wind
 - `adaptivePollingInterval` **(optional)** poll interval in seconds during high frequency polling. Default value is `1` second.
 - `forceCurrentPosition` **(optional)** when set to `true` the position set by `set_TargetPosition` is directly used as current position. By this it seems in tha home app as the target position was directly reached. This is recommended when not using `adaptivePolling` or pushing the value from the plc.
 - `enablePolling`: **(optional)** when set to `true` the current state will be polled. It is mandatory as well to enable polling mode on platform level.
-- `pollInterval` **(optional)** poll interval in seconds. Default value is `10` seconds.
+- `pollInterval` **(optional)** poll interval in seconds. Default value see platform definition.
 - `get_CurrentPosition`: **(push support)** offset to get current position S7 type `Byte` e.g. `0` for `DB4DBB0`
 - if one of the **(optional)** target position settings need specified all are needed. If not specified it os not movable ans sticks to current position.
 	- `get_TargetPosition`: **(optional)** **(push support)** offset to get target position S7 type `Byte` e.g. `1` for `DB4DBB1` (can have same value as set_TargetPosition)
@@ -219,7 +221,7 @@ presence detection sensor
 - `manufacturer`: **(optional)** description
 - `db`: s7 data base number e.g. `4` for `DB4`
 - `enablePolling`: **(optional)** when set to `true` the current state will be polled. It is mandatory as well to enable polling mode on platform level.
-- `pollInterval` **(optional)** poll interval in seconds. Default value is `10` seconds.
+- `pollInterval` **(optional)** poll interval in seconds. Default value see platform definition.
 - `get_OccupancyDetected`: **(push support)** offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`
 	- `false`: no occupancy
 	- `true`: occupancy detected
@@ -232,7 +234,7 @@ movement detection sensor
 - `manufacturer`: **(optional)** description
 - `db`: s7 data base number e.g. `4` for `DB4`
 - `enablePolling`: **(optional)** when set to `true` the current state will be polled. It is mandatory as well to enable polling mode on platform level.
-- `pollInterval` **(optional)** poll interval in seconds. Default value is `10` seconds.
+- `pollInterval` **(optional)** poll interval in seconds. Default value see platform definition.
 - `get_MotionDetected`: **(push support)** offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`
 	- `false`: no motion
 	- `true`: motion detected
@@ -245,7 +247,7 @@ Generic contact sensor. The home app allows to display as window, door, blind/sh
 - `manufacturer`: **(optional)** description
 - `db`: s7 data base number e.g. `4` for `DB4`
 - `enablePolling`: **(optional)** when set to `true` the current state will be polled. It is mandatory as well to enable polling mode on platform level.
-- `pollInterval` **(optional)** poll interval in seconds. Default value is `10` seconds.
+- `pollInterval` **(optional)** poll interval in seconds. Default value see platform definition.
 - `get_ContactSensorState`: **(push support)** offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`
 	- `false`: closed
 	- `true`: open
@@ -258,7 +260,7 @@ watering for the garden
 - `manufacturer`: **(optional)** description
 - `db`: s7 data base number e.g. `4` for `DB4`
 - `enablePolling`: **(optional)** when set to `true` the current state will be polled. It is mandatory as well to enable polling mode on platform level.
-- `pollInterval` **(optional)** poll interval in seconds. Default value is `10` seconds.
+- `pollInterval` **(optional)** poll interval in seconds. Default value see platform definition.
 - `get_Active`: **(push support)** offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`
 - Single Bit for on/off:
 	- `set_Active`: **(control support)** offset and bit set to 1/0 when switching on/off S7 type `Bool` PLC e.g. `55.0` for `DB4DBX55.0` could be same as get_Active
@@ -274,7 +276,7 @@ valve configurable as generic valve, irrigation, shower head or water faucet
 - `manufacturer`: **(optional)** description
 - `db`: s7 data base number e.g. `4` for `DB4`
 - `enablePolling`: **(optional)** when set to `true` the current state will be polled. It is mandatory as well to enable polling mode on platform level.
-- `pollInterval` **(optional)** poll interval in seconds. Default value is `10` seconds.
+- `pollInterval` **(optional)** poll interval in seconds. Default value see platform definition.
 - `ValveType` configures the valve type that is returned
 	- `0`: generic valve
 	- `1`: irrigation
@@ -299,7 +301,7 @@ alarm system
 - `manufacturer`: **(optional)** description
 - `db`: s7 data base number e.g. `4` for `DB4`
 - `enablePolling`: **(optional)** when set to `true` the current state of the security system will be polled.
-- `pollInterval` **(optional)** poll interval in seconds. Default value is `10` seconds.
+- `pollInterval` **(optional)** poll interval in seconds. Default value see platform definition.
 - `get_SecuritySystemCurrentState`: **(push support)** offset to current security system state S7 type `Byte` e.g. `3` for `DB4DBB3`
 	- `0`: armed stay at home
 	- `1`: armed away from home
@@ -331,7 +333,7 @@ Trigger actions in home app only works with control center e.g. AppleTV or HomeP
 - `manufacturer`: **(optional)** description
 - `db`: s7 data base number e.g. `4` for `DB4`
 - `enablePolling`: **(optional)** when set to `true` the current state will be polled. It is mandatory as well to enable polling mode on platform level.
-- `pollInterval` **(optional)** poll interval in seconds. Default value is `10` seconds.
+- `pollInterval` **(optional)** poll interval in seconds. Default value see platform definition.
 - `isEvent` offset and bit that is polled by homebridge-plc. **PLC has to set to `true`.** When `true` the event is read from `get_ProgrammableSwitchEvent` and set to `false` by homebirdge-plc to confirm that the event is handled. S7 type `Bool` e.g. `55.1` for `DB4DBX55.1` (polling only, not used for push)
 - `get_ProgrammableSwitchEvent`: **(push support)** **(control support)** offset to read current event of the switch. This is reported towards home app S7 type `Byte` e.g. `3` for `DB4DBB3`
 	- `0`: single press
@@ -346,7 +348,7 @@ Lock mechanism (not yet clear how to use changes are welcome)
 - `manufacturer`: **(optional)** description
 - `db`: s7 data base number e.g. `4` for `DB4`
 - `enablePolling`: **(optional)** when set to `true` the current state will be polled. It is mandatory as well to enable polling mode on platform level.
-- `pollInterval` **(optional)** poll interval in seconds. Default value is `10` seconds.
+- `pollInterval` **(optional)** poll interval in seconds. Default value see platform definition.
 - `forceCurrentState`: **(optional)** when set to `true` the position set by `set_LockTargetState` is directly used as current state. By this it seems in the home app as the target state was directly reached. This is recommended when not using `enablePolling` or pushing the value from the plc.
 	- `get_LockCurrentState`: **(push support)** offset to read current state current state S7 type `Byte` e.g. `3` for `DB4DBB3`
 		- `0`: unsecured
@@ -368,7 +370,7 @@ Lock mechanism implemented as bool on the PLC. **NOTE: The convention `0`=`false
 - `manufacturer`: **(optional)** description
 - `db`: s7 data base number e.g. `4` for `DB4`
 - `enablePolling`: **(optional)** when set to `true` the current state will be polled. t is mandatory as well to enable polling mode on platform level.
-- `pollInterval` **(optional)** poll interval in seconds. Default value is `10` seconds.
+- `pollInterval` **(optional)** poll interval in seconds. Default value see platform definition.
 - `forceCurrentState`: **(optional)** when set to `true` the position set by `set_LockTargetState` is directly used as current state. By this it seems in the home app as the target state was directly reached. This is recommended when not using `enablePolling` or pushing the value from the plc.
 - `get_LockCurrentState`: **(push support)** offset to read current state current state S7 type `Bool` .g. `3.1` for `DB4DBB3`
 	- `false`: secured
@@ -393,7 +395,7 @@ Garage door
 - `manufacturer`: **(optional)** description
 - `db`: s7 data base number e.g. `4` for `DB4`
 - `enablePolling`: **(optional)** when set to `true` the current state will be polled. It is mandatory as well to enable polling mode on platform level.
-- `pollInterval` **(optional)** poll interval in seconds. Default value is `10` seconds.
+- `pollInterval` **(optional)** poll interval in seconds. Default value see platform definition.
 - `forceCurrentState`: **(optional)** when set to `true` the position set by `set_TargetDoorState` is directly used as current state. By this it seems in the home app as the target state was directly reached. This is recommended when not using `enablePolling` or pushing the value from the plc.
 - `get_ObstructionDetected` **(optional)** **(push support)** offset and bit to obfuscation detection true means that the door was blocked S7 type `Bool` e.g. `55.1` for `DB4DBX55.1`
 - `get_CurrentDoorState`: **(push support)** offset to read current state current state S7 type `Byte` e.g. `3` for `DB4DBB3`
@@ -416,7 +418,7 @@ Fire alarm
 - `manufacturer`: **(optional)** description
 - `db`: s7 data base number e.g. `4` for `DB4`
 - `enablePolling`: **(optional)** when set to `true` the current state will be polled. It is mandatory as well to enable polling mode on platform level.
-- `pollInterval`: **(optional)** poll interval in seconds. Default value is `10` seconds.
+- `pollInterval`: **(optional)** poll interval in seconds. Default value see platform definition.
 - `get_SmokeDetected`: **(push support)** offset and bit to smoke detection. S7 type `Bool` e.g. `55.1` for `DB4DBX55.1`
 	- `false`: ok
 	- `true`: smoke detected
@@ -451,6 +453,11 @@ Note: The example is just an example it contains also some optional settings. Fo
 				"rack": 0,
 				"slot": 2,
 				"enablePolling": true,
+				"defaultPollInterval": 15,
+				"distributePolling": true,
+				"enablePush": true,
+				"enableControl": true,
+				"port": 8888,
 				"accessories": [
 					{
 						"accessory": "PLC_LightBulb",

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Parameters:
 - `distributePolling` **(optional)** when set to `true` the polling of the accessories does not start at the same time. In order to distribute the PLC load for the queries.
 - `enablePush`: **(optional)** when set to `true` a the configured `port` is opened to push updates of values form plc to the plugin
 - `enableControl`: **(optional)** when set to `true` a the configured `port` is opened to control accessories by http request
-- `port`: **(optional)** port for http requests default `8888`
+- `port`: **(optional)** port for http server to handle incoming http requests for push and control functionality. Default port is `8888`
 
 ## Accessories
 - In the platform, you can declare different types of accessories

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 /*
- * (c) 2020 Feilner
+ * (c) 2020-2021 Feilner
  */
 
 var PlatformAccessory, Service, Characteristic, UUIDGen;

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ PLC_Platform.prototype = {
       });
       callback(this.s7PlatformAccessories);
 
-      if (this.config.enablePolling) {        
+      if (this.config.enablePolling) {
         log("Enable polling...");
         setInterval(function(param) {this.pollLoop( this.s7PlatformAccessories);}.bind(this),1000);
       }
@@ -198,7 +198,7 @@ function GenericPLCAccessory(platform, config, accessoryNumber) {
 
   if ('enablePolling' in platform.config && platform.config.enablePolling && config.enablePolling) {
       this.pollActive = true;
-      this.pollInterval =  config.pollInterval || platform.config.defaultPollInterval;      
+      this.pollInterval =  config.pollInterval || platform.config.defaultPollInterval;
       if (platform.config.distributePolling) {
         this.pollCounter = (accessoryNumber % this.pollInterval) + 1;
       }

--- a/index.js
+++ b/index.js
@@ -45,8 +45,8 @@ PLC_Platform.prototype = {
       callback(this.s7PlatformAccessories);
 
       if (this.config.enablePolling) {        
-        setInterval(function(param) {this.pollLoop( this.s7PlatformAccessories);}.bind(this),1000);
         log("Enable polling...");
+        setInterval(function(param) {this.pollLoop( this.s7PlatformAccessories);}.bind(this),1000);
       }
 
       if (this.config.enablePush || this.config.enableControl) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-plc",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "Homebridge plugin for Siemens Step7 and compatible PLCs. (https://github.com/homebridge)",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## [1.0.22] - 2021-01-01

### Changed
- changed **default value** for parameter `port` from `8080` to `8888`. This was done to avoid conflicts with Homebridge UI which has 8080 as default port. The port is used when using `enablePush` or `enableControl` is set. **(check your config)**

### Added
- add option `defaultPollInterval` on platform level
- add option `distributePolling` on platform level