### PR TITLE
Added invert configuration option for OccupancySensors, MotionSensors and ContactSensors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ presence detection sensor
 - `name`: unique name of the accessory
 - `manufacturer`: **(optional)** description
 - `db`: s7 data base number e.g. `4` for `DB4`
+- `invert`: **(optional)** set to `true` inverts the bit to `false:presence` and `true:no-presence`.
 - `enablePolling`: **(optional)** when set to `true` the current state will be polled. It is mandatory as well to enable polling mode on platform level.
 - `pollInterval` **(optional)** poll interval in seconds. Default value see platform definition.
 - `get_OccupancyDetected`: **(push support)** offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`
@@ -233,6 +234,7 @@ movement detection sensor
 - `name`: unique name of the accessory
 - `manufacturer`: **(optional)** description
 - `db`: s7 data base number e.g. `4` for `DB4`
+- `invert`: **(optional)** set to `true` inverts the bit to `false:motion` and `true:no-motion`.
 - `enablePolling`: **(optional)** when set to `true` the current state will be polled. It is mandatory as well to enable polling mode on platform level.
 - `pollInterval` **(optional)** poll interval in seconds. Default value see platform definition.
 - `get_MotionDetected`: **(push support)** offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`
@@ -246,6 +248,7 @@ Generic contact sensor. The home app allows to display as window, door, blind/sh
 - `name`: unique name of the accessory
 - `manufacturer`: **(optional)** description
 - `db`: s7 data base number e.g. `4` for `DB4`
+- `invert`: **(optional)** set to `true` inverts the bit to `false:closed` and `true:open`.
 - `enablePolling`: **(optional)** when set to `true` the current state will be polled. It is mandatory as well to enable polling mode on platform level.
 - `pollInterval` **(optional)** poll interval in seconds. Default value see platform definition.
 - `get_ContactSensorState`: **(push support)** offset and bit get the current status S7 type `Bool` e.g. `55.0` for `DB4DBX55.0`

--- a/index.js
+++ b/index.js
@@ -522,11 +522,17 @@ function GenericPLCAccessory(platform, config, accessoryNumber) {
     this.service = new Service.OccupancySensor(this.name);
     this.accessory.addService(this.service);
 
+    this.modBitGet = this.plain
+    if ('invert' in config && config.invert) {
+        this.modBitGet = this.invert_bit;
+    }
+
     this.service.getCharacteristic(Characteristic.OccupancyDetected)
       .on('get', function(callback) {this.getBit(callback,
         config.db,
         Math.floor(config.get_OccupancyDetected), Math.floor((config.get_OccupancyDetected*10)%10),
-        "get OccupancyDetected"
+        "get OccupancyDetected",
+        this.modBitGet
       );}.bind(this));
   }
   // INIT handling ///////////////////////////////////////////////
@@ -536,11 +542,17 @@ function GenericPLCAccessory(platform, config, accessoryNumber) {
     this.service = new Service.MotionSensor(this.name);
     this.accessory.addService(this.service);
 
+    this.modBitGet = this.plain
+    if ('invert' in config && config.invert) {
+        this.modBitGet = this.invert_bit;
+    }
+
     this.service.getCharacteristic(Characteristic.MotionDetected)
       .on('get', function(callback) {this.getBit(callback,
         config.db,
         Math.floor(config.get_MotionDetected), Math.floor((config.get_MotionDetected*10)%10),
-        "get MotionDetected"
+        "get MotionDetected",
+        this.modBitGet
       );}.bind(this));
   }
   // INIT handling ///////////////////////////////////////////////
@@ -549,12 +561,18 @@ function GenericPLCAccessory(platform, config, accessoryNumber) {
   else if (config.accessory == 'PLC_ContactSensor'){
     this.service = new Service.ContactSensor(this.name);
     this.accessory.addService(this.service);
-
-    this.service.getCharacteristic(Characteristic.ContactSensorState)
+    
+    this.modBitGet = this.plain
+    if ('invert' in config && config.invert) {
+        this.modBitGet = this.invert_bit;
+    }
+    
+      this.service.getCharacteristic(Characteristic.ContactSensorState)
       .on('get', function(callback) {this.getBit(callback,
         config.db,
         Math.floor(config.get_ContactSensorState), Math.floor((config.get_ContactSensorState*10)%10),
-        "get get_ContactSensorState"
+        "get get_ContactSensorState",
+        this.modBitGet
       );}.bind(this));
   }
   // INIT handling ///////////////////////////////////////////////
@@ -1615,6 +1633,10 @@ GenericPLCAccessory.prototype = {
 
   invert_0_100: function(value) {
     return 100-value;
+  },
+
+  invert_bit: function(value) {
+    return 1 - value;
   },
 
   mapFunction: function(value, map) {

--- a/index.js
+++ b/index.js
@@ -522,9 +522,9 @@ function GenericPLCAccessory(platform, config, accessoryNumber) {
     this.service = new Service.OccupancySensor(this.name);
     this.accessory.addService(this.service);
 
-    this.modBitGet = this.plain
+    this.modFunctionGet = this.plain
     if ('invert' in config && config.invert) {
-        this.modBitGet = this.invert_bit;
+        this.modFunctionGet = this.invert_bit;
     }
 
     this.service.getCharacteristic(Characteristic.OccupancyDetected)
@@ -532,7 +532,7 @@ function GenericPLCAccessory(platform, config, accessoryNumber) {
         config.db,
         Math.floor(config.get_OccupancyDetected), Math.floor((config.get_OccupancyDetected*10)%10),
         "get OccupancyDetected",
-        this.modBitGet
+        this.modFunctionGet
       );}.bind(this));
   }
   // INIT handling ///////////////////////////////////////////////
@@ -542,9 +542,9 @@ function GenericPLCAccessory(platform, config, accessoryNumber) {
     this.service = new Service.MotionSensor(this.name);
     this.accessory.addService(this.service);
 
-    this.modBitGet = this.plain
+    this.modFunctionGet = this.plain;
     if ('invert' in config && config.invert) {
-        this.modBitGet = this.invert_bit;
+        this.modFunctionGet = this.invert_bit;
     }
 
     this.service.getCharacteristic(Characteristic.MotionDetected)
@@ -552,7 +552,7 @@ function GenericPLCAccessory(platform, config, accessoryNumber) {
         config.db,
         Math.floor(config.get_MotionDetected), Math.floor((config.get_MotionDetected*10)%10),
         "get MotionDetected",
-        this.modBitGet
+        this.modFunctionGet
       );}.bind(this));
   }
   // INIT handling ///////////////////////////////////////////////
@@ -562,9 +562,9 @@ function GenericPLCAccessory(platform, config, accessoryNumber) {
     this.service = new Service.ContactSensor(this.name);
     this.accessory.addService(this.service);
     
-    this.modBitGet = this.plain
+    this.modFunctionGet = this.plain;
     if ('invert' in config && config.invert) {
-        this.modBitGet = this.invert_bit;
+        this.modFunctionGet = this.invert_bit;
     }
     
       this.service.getCharacteristic(Characteristic.ContactSensorState)
@@ -572,7 +572,7 @@ function GenericPLCAccessory(platform, config, accessoryNumber) {
         config.db,
         Math.floor(config.get_ContactSensorState), Math.floor((config.get_ContactSensorState*10)%10),
         "get get_ContactSensorState",
-        this.modBitGet
+        this.modFunctionGet
       );}.bind(this));
   }
   // INIT handling ///////////////////////////////////////////////
@@ -1067,8 +1067,8 @@ GenericPLCAccessory.prototype = {
     else if (this.config.accessory == 'PLC_OccupancySensor'){
       if (this.config.get_OccupancyDetected == offset)
       {
-        this.log.debug( "[" + this.name + "] Push OccupancyDetected:" + value);
-        this.service.getCharacteristic(Characteristic.OccupancyDetected).updateValue(value);
+        this.log.debug( "[" + this.name + "] Push OccupancyDetected:" + String(this.modFunctionGet(parseInt(value))) + "<-" + String(value));
+        this.service.getCharacteristic(Characteristic.OccupancyDetected).updateValue(this.modFunctionGet(parseInt(value)));
         rv = true;
       }
     }
@@ -1078,8 +1078,8 @@ GenericPLCAccessory.prototype = {
     else if (this.config.accessory == 'PLC_MotionSensor'){
       if (this.config.get_MotionDetected == offset)
       {
-        this.log.debug( "[" + this.name + "] Push MotionDetected:" + value);
-        this.service.getCharacteristic(Characteristic.MotionDetected).updateValue(value);
+        this.log.debug( "[" + this.name + "] Push MotionDetected:" + String(this.modFunctionGet(parseInt(value))) + "<-" + String(value));
+        this.service.getCharacteristic(Characteristic.MotionDetected).updateValue(this.modFunctionGet(parseInt(value)));
         rv = true;
       }
     }
@@ -1089,8 +1089,8 @@ GenericPLCAccessory.prototype = {
     else if (this.config.accessory == 'PLC_ContactSensor'){
       if (this.config.get_ContactSensorState == offset)
       {
-        this.log.debug( "[" + this.name + "] Push ContactSensorState:" + value);
-        this.service.getCharacteristic(Characteristic.ContactSensorState).updateValue(value);
+        this.log.debug( "[" + this.name + "] Push ContactSensorState:" + String(this.modFunctionGet(parseInt(value))) + "<-" + String(value));
+        this.service.getCharacteristic(Characteristic.ContactSensorState).updateValue(this.modFunctionGet(parseInt(value)));
         rv = true;
       }
     }
@@ -1636,7 +1636,7 @@ GenericPLCAccessory.prototype = {
   },
 
   invert_bit: function(value) {
-    return 1 - value;
+    return (value ? 0 : 1);
   },
 
   mapFunction: function(value, map) {


### PR DESCRIPTION
Sometimes simple 'bit' sensors are being tracked the other way round within S7 and there is no chance to change the functions that write DB values.
Therefore a configuration option of simply swapping the bit would be great.
This pull request adds this feature for OccupancySensors, MotionSensors and ContactSensors.