### PR TITLE
V1.0.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.0.26] 2021-02-14
+
+### Changed
+- `PLC_TemperatureSensor`: default maxValue increased from 50 to 110
+- `PLC_Thermostat` remove warning when using `get_StatusTampered` or `get_StatusLowBattery` was no success remove useless code.
 
 ## [1.0.25] 2021-01.19
 

--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ normal temperature sensor
 - `get_CurrentTemperature`: **(push support)** offset to get current temperature S7 type `Real` e.g. `55` for `DB4DBD55`
 - temperature range **(optional)**
 	- `minValue` default value: -50
-	- `maxValue` default value: 50
-	- `minStep` default value: 0.5
+	- `maxValue` default value: 110
+	- `minStep` default value: 0.1
 - `get_StatusTampered`: **(optional)** **(push support)** offset and bit to tamper detection. (Home app shows this only within the options) S7 type `Bool` e.g. `55.2` for `DB4DBX55.2`
 	- `false`: ok
 	- `true`: tampered

--- a/index.js
+++ b/index.js
@@ -295,9 +295,10 @@ function GenericPLCAccessory(platform, config, accessoryNumber) {
       );}.bind(this))
     .setProps({
       minValue: config.minValue || -50,
-      maxValue: config.maxValue || 50,
+      maxValue: config.maxValue || 110,
       minStep: config.minStep || 0.5
     });
+
     if ('get_StatusTampered' in config) {
       this.service.getCharacteristic(Characteristic.StatusTampered)
       .on('get', function(callback) {this.getBit(callback,
@@ -491,8 +492,7 @@ function GenericPLCAccessory(platform, config, accessoryNumber) {
     }
 
     if ('get_StatusTampered' in config) {
-      //Silence warning that the characteristic is not supported.
-      this.service.addCharacteristic(Characteristic.StatusTampered);
+      //This will generate a warning but will work anyway.
       this.service.getCharacteristic(Characteristic.StatusTampered)
       .on('get', function(callback) {this.getBit(callback,
         config.db,
@@ -502,8 +502,7 @@ function GenericPLCAccessory(platform, config, accessoryNumber) {
     }
 
     if ('get_StatusLowBattery' in config) {
-      //Silence warning that the characteristic is not supported.
-      this.service.addCharacteristic(Characteristic.StatusLowBattery);
+      //This will generate a warning but will work anyway.
       this.service.getCharacteristic(Characteristic.StatusLowBattery)
       .on('get', function(callback) {this.getBit(callback,
         config.db,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-plc",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "Homebridge plugin for Siemens Step7 and compatible PLCs. (https://github.com/homebridge)",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
- `PLC_TemperatureSensor`: default maxValue increased from 50 to 110
- `PLC_Thermostat` remove warning when using `get_StatusTampered` or `get_StatusLowBattery` was no success remove useless code.