### PR TITLE
1.0.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [1.0.29] 2021-04-21
+
+### Fixed
+- Correct option `mapSetTarget`, `mapGetTarget`  and `mapGetCurrent` function for `PLC_Thermostat` and `PLC_HumidifierDehumidifier`
 
 ## [1.0.28] 2021-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 ## [1.0.29] 2021-04-21
 
 ### Fixed
-- Correct option `mapSetTarget`, `mapGetTarget`  and `mapGetCurrent` function for `PLC_Thermostat` and `PLC_HumidifierDehumidifier`
+- `PLC_HumidifierDehumidifier` correct option `mapSetTarget`, `mapGetTarget`  and `mapGetCurrent`
+- `PLC_Thermostat` correct option `mapSetTarget`, `mapGetTarget`  and `mapGetCurrent`
+
+### Changed
+- `PLC_SecuritySystem` introduce `mapSetTarget`, `mapGetTarget`  and `mapGetCurrent` this replaces `mapSet` and `mapGet`. (For backwards compatibility old options are still supported)
 
 ## [1.0.28] 2021-02-26
 

--- a/README.md
+++ b/README.md
@@ -195,13 +195,13 @@ temperature / humidity sensor with temperature / humidity regulation
 		- `minHumidityValue` default value: 0
 		- `maxHumidityValue` default value: 100
 		- `minHumidityStep` default value: 1
-- Heating Cooling State
+- Current State:
   - `get_CurrentHeatingCoolingState`: **(optional)** **(push support)** offset to get current heating/cooling state S7 type `Byte` e.g. `8` for `DB4DBB8`. When not defined fixed `1`: heating is used.
   	- `0`: inactive (shown as green in home app)
   	- `1`: heating (shown as orange in home app)
   	- `2`: cooling (shown as blue in home app)
   - `mapGetCurrent`: **(optional)** define mapping array for `get_CurrentHeatingCoolingState`. The PLC value is used as index into the table. e.g. `[0, 2]` which maps the PLC value `0->0 1->2` when the PLC supports only two states with `0:inactive` and `1:cooling`.
-  
+- Target State:
   - `get_TargetHeatingCoolingState` **(optional)** **(push support)** offset to get target heating/cooling state. S7 type `Byte` e.g. `9` for `DB4DBB9`. When not defined fixed `3`: automatic is used.
   	- `0`: off
   	- `1`: heat
@@ -241,7 +241,7 @@ Humidifier and/or Dehumidifier
   	- `2`: humidifying
   	- `3`: dehumidifying
   - `mapGetCurrent`: **(optional)** define mapping array for `get_CurrentHumidifierDehumidifierState`. The PLC value is used as index into the table. e.g. `[1, 3]` which maps the PLC value `0->1 1->3` when the PLC supports only two states with `0:idle` and `1:dehumidifying`.
-- Target State 
+- Target State
   - `default_TargetHumidifierDehumidifierState`: **(optional)** defines alternative value thats returned then `get_TargetHumidifierDehumidifierState` is not defined. Default value `0:auto`
   	- `0`: auto (humidifier or dehumidifier)
   	- `1`: humidifier
@@ -279,17 +279,29 @@ motor driven blinds, windows and doors. Supports also manual driven blinds, wind
 - `name`: unique name of the accessory
 - `manufacturer`: **(optional)** description
 - `db`: s7 data base number e.g. `4` for `DB4`
-- `invert`: **(optional)** set to `true` to inverts the meanings of the values from `0:closed 100:open` to `100:closed 0:open`
-- `mapGet`: **(optional)** define mapping array for get position. The PLC value is used as index into the table. e.g. `[0, 25, 100]` which maps the PLC value `0->0 1->25 2->100` this this is useful e.g. for window open state.
 - `adaptivePolling`: **(optional)** when set to `true` the current position will be polled until target position is reached. Polling starts with set target position from home app. This allows to show the shutter as opening... or closing... in the home app during movement.
 - `adaptivePollingInterval` **(optional)** poll interval in seconds during high frequency polling. Default value is `1` second.
 - `forceCurrentPosition` **(optional)** when set to `true` the position set by `set_TargetPosition` is directly used as current position. By this it seems in tha home app as the target position was directly reached. This is recommended when not using `adaptivePolling` or pushing the value from the plc.
 - `enablePolling`: **(optional)** when set to `true` the current state will be polled. It is mandatory as well to enable polling mode on platform level.
 - `pollInterval`: **(optional)** poll interval in seconds. Default value see platform definition.
-- `get_CurrentPosition`: **(push support)** offset to get current position S7 type `Byte` e.g. `0` for `DB4DBB0`
-- if one of the **(optional)** target position settings need specified all are needed. If not specified it os not movable ans sticks to current position.
-	- `get_TargetPosition`: **(optional)** **(push support)** offset to get target position S7 type `Byte` e.g. `1` for `DB4DBB1` (can have same value as set_TargetPosition)
-	- `set_TargetPosition`: **(optional)** **(control support)** offset to set current position S7 type `Byte` e.g. `2` for `DB4DBB2` (can have same value as get_TargetPosition)
+- Current position:
+  - `get_CurrentPosition`: **(push support)** offset to get current position `0:closed 100:open` S7 type `Byte` e.g. `0` for `DB4DBB0`
+    - `0`: closed
+    - `in between`: partly open
+    - `100`: open
+  - `invert`: **(optional)** set to `true` to inverts the values of current and target position from `0:closed 100:open` to `100:closed 0:open`
+  - `mapGet`: **(optional)** define mapping array for get position. The PLC value is used as index into the table. e.g. `[0, 25, 100]` which maps the PLC value `0->0 1->25 2->100` this this is useful e.g. for window open state.
+- Target position:
+  -  if one of the **(optional)** target position settings need specified all are needed. If not specified it os not movable ans sticks to current position.
+  - `get_TargetPosition`: **(optional)** **(push support)** offset to get target position S7 type `Byte` e.g. `1` for `DB4DBB1` (can have same value as set_TargetPosition)
+    	- `0`: closed
+    	- `in between`: partly open
+    	- `100`: open
+  - `set_TargetPosition`: **(optional)** **(control support)** offset to set current position `0:closed 100:open` S7 type `Byte` e.g. `2` for `DB4DBB2` (can have same value as get_TargetPosition)
+    - `0`: closed
+    - `in between`: partly open
+    - `100`: open
+  - `invert`: **(optional)** set to `true` to inverts the values of current and target position from `0:closed 100:open` to `100:closed 0:open`
 - `get_PositionState`: **(optional)** **(push support)** offset to current movement state if not defined fixed `2`is returned S7 type `Byte` e.g. `3` for `DB4DBB3`
 	- `0`: down
 	- `1`: up
@@ -406,20 +418,25 @@ alarm system
 - `db`: s7 data base number e.g. `4` for `DB4`
 - `enablePolling`: **(optional)** when set to `true` the current state of the security system will be polled.
 - `pollInterval`: **(optional)** poll interval in seconds. Default value see platform definition.
-- `get_SecuritySystemCurrentState`: **(push support)** offset to current security system state S7 type `Byte` e.g. `3` for `DB4DBB3`
-	- `0`: armed stay at home
-	- `1`: armed away from home
-	- `2`: armed night
-	- `3`: disarmed
-	- `4`: alarm triggered
-- `set_SecuritySystemTargetState`: **(control support)** offset to set target security system state S7 type `Byte` e.g. `5` for `DB4DBB4`
-- `get_SecuritySystemTargetState`: **(push support)** offset to set target security system state S7 type `Byte` e.g. `6` for `DB4DBB6`
-	- `0`: armed stay at home
-	- `1`: armed away from home
-	- `2`: armed night
-	- `3`: disarmed
-- `mapGet`: **(optional)** define mapping array for get security system state. The PLC value is used as index into the table. e.g. `[3, 1]` which maps the PLC value `0->3 1->2` when the PLC supports only two states with `0:disarmed` and `1:armed` and `2:alarm`.
-- `mapSet`: **(optional)** define mapping array for set security system state. The home app value is used as index into the table. e.g. `[1, 1, 1, 0, 2]` which maps the PLC value `0->1 1->1 2->1, 3->0, 4->2` when the PLC supports only two states with `0:disarmed` and `1:armed` and `2:alarm`.
+- Current State:
+  - `get_SecuritySystemCurrentState`: **(push support)** offset to current security system state S7 type `Byte` e.g. `3` for `DB4DBB3`
+  	- `0`: armed stay at home
+  	- `1`: armed away from home
+  	- `2`: armed night
+  	- `3`: disarmed
+  	- `4`: alarm triggered
+  - `mapGetCurrent`: **(optional)** define mapping array for get security system state. The PLC value is used as index into the table. e.g. `[3, 1]` which maps the PLC value `0->3 1->2` when the PLC supports only two states with `0:disarmed` and `1:armed` and `2:alarm`.
+- Target State:
+  - `set_SecuritySystemTargetState`: **(control support)** offset to set target security system state S7 type `Byte` e.g. `5` for `DB4DBB4`
+  - `get_SecuritySystemTargetState`: **(push support)** offset to set target security system state S7 type `Byte` e.g. `6` for `DB4DBB6`
+  	- `0`: armed stay at home
+  	- `1`: armed away from home
+  	- `2`: armed night
+  	- `3`: disarmed
+  - `mapSetTarget`: **(optional)** define mapping array for set security system state. The home app value is used as index into the table. e.g. `[1, 1, 1, 0, 2]` which maps the PLC value `0->1 1->1 2->1, 3->0, 4->2` when the PLC supports only two states with `0:disarmed` and `1:armed` and `2:alarm`.
+  - `mapGetTarget`: **(optional)** define mapping array for get security system state. The PLC value is used as index into the table. e.g. `[3, 1]` which maps the PLC value `0->3 1->2` when the PLC supports only two states with `0:disarmed` and `1:armed` and `2:alarm`.
+- `mapGet` **(obsolete)** **(optional)** overwrites `mapGetCurrent`and `mapGetTarget`
+- `mapSet` **(obsolete)** **(optional)** overwrites `mapSetTarget`
 
 ### <a name='PLC_StatelessProgrammableSwitch'></a>Button as `PLC_StatelessProgrammableSwitch`, Doorbell as `PLC_Doorbell`
 stateless switch from PLC to home app.
@@ -738,19 +755,22 @@ Note: The example is just an example it contains also some optional settings. Fo
 						"get_SecuritySystemCurrentState": 26,
 						"set_SecuritySystemTargetState": 27,
 						"get_SecuritySystemTargetState": 27,
-						"mapGet": [
-								1,
-								1,
-								1,
+						"mapGetCurrent": [
 								3,
+								1,
 								4
 						],
-						"mapSet": [
-								1,
-								1,
-								1,
-								3
+						"mapGetTarget": [
+								3,
+								1
 						]
+						"mapSetTarget": [
+								1,
+								1,
+								1,
+								0
+						]
+
 					},
 					{
 						"accessory": "PLC_StatelessProgrammableSwitch",

--- a/index.js
+++ b/index.js
@@ -1071,6 +1071,7 @@ function GenericPLCAccessory(platform, config, accessoryNumber) {
   else if (config.accessory == 'PLC_SecuritySystem'){
     this.service = new Service.SecuritySystem(this.name);
     this.accessory.addService(this.service);
+    this.modFunctionGetCurrent = this.plain;
 
     informFunction = function(notUsed){
       // get the current target system state and update the value.
@@ -1090,9 +1091,22 @@ function GenericPLCAccessory(platform, config, accessoryNumber) {
     if ('mapSet' in config && config.mapSet) {
       this.modFunctionSet = function(value){return this.mapFunction(value, config.mapSet);}.bind(this);
     }
+    else if ('mapSetTarget' in config && config.mapSetTarget) {
+      this.modFunctionSet = function(value){return this.mapFunction(value, config.mapSetTarget);}.bind(this);
+    }
 
     if ('mapGet' in config && config.mapGet) {
       this.modFunctionGet = function(value){return this.mapFunction(value, config.mapGet);}.bind(this);
+      this.modFunctionGetCurrent = function(value){return this.mapFunction(value, config.mapGet);}.bind(this);
+    }
+    else {
+      if ('mapGetTarget' in config && config.mapGetTarget) {
+        this.modFunctionGet = function(value){return this.mapFunction(value, config.mapGetTarget);}.bind(this);
+      }
+
+      if ('mapGetCurrent' in config && config.mapGetCurrent) {
+        this.modFunctionGetCurrent = function(value){return this.mapFunction(value, config.mapGetCurrent);}.bind(this);
+      }
     }
 
     this.service.getCharacteristic(Characteristic.SecuritySystemCurrentState)
@@ -1100,7 +1114,7 @@ function GenericPLCAccessory(platform, config, accessoryNumber) {
         config.db,
         config.get_SecuritySystemCurrentState,
         "get SecuritySystemCurrentState",
-        this.modFunctionGet
+        this.modFunctionGetCurrent
       );}.bind(this));
 
       this.service.getCharacteristic(Characteristic.SecuritySystemTargetState)
@@ -1495,7 +1509,7 @@ GenericPLCAccessory.prototype = {
         rv = true;
       }
       if (this.config.get_TargetHumidifierDehumidifierState == offset)
-      {       
+      {
         this.log.debug( "[" + this.name + "] Push TargetHumidifierDehumidifierState:" + String(this.modFunctionGet(parseInt(value))) + "<-" + String(value));
         this.service.getCharacteristic(Characteristic.TargetHumidifierDehumidifierState).updateValue(this.modFunctionGet(parseInt(value)));
         rv = true;
@@ -1686,8 +1700,8 @@ GenericPLCAccessory.prototype = {
     else if (this.config.accessory == 'PLC_SecuritySystem'){
       if (this.config.get_SecuritySystemCurrentState == offset)
       {
-        this.log.debug( "[" + this.name + "] Push SecuritySystemCurrentState:" + String(this.modFunctionGet(parseInt(value))) + "<-" + String(value));
-        this.service.getCharacteristic(Characteristic.SecuritySystemCurrentState).updateValue(this.modFunctionGet(parseInt(value)));
+        this.log.debug( "[" + this.name + "] Push SecuritySystemCurrentState:" + String(this.modFunctionGetCurrent(parseInt(value))) + "<-" + String(value));
+        this.service.getCharacteristic(Characteristic.SecuritySystemCurrentState).updateValue(this.modFunctionGetCurrent(parseInt(value)));
         rv = true;
       }
       if (this.config.get_SecuritySystemTargetState == offset)

--- a/index.js
+++ b/index.js
@@ -377,16 +377,16 @@ function GenericPLCAccessory(platform, config, accessoryNumber) {
       }.bind(this));
      }.bind(this);
 
-    if ('mapSetTarget' in config && config.mapSet) {
+    if ('mapSetTarget' in config && config.mapSetTarget) {
       this.modFunctionSet = function(value){return this.mapFunction(value, config.mapSetTarget);}.bind(this);
     }
 
-    if ('mapGetTarget' in config && config.mapGet) {
+    if ('mapGetTarget' in config && config.mapGetTarget) {
       this.modFunctionGet = function(value){return this.mapFunction(value, config.mapGetTarget);}.bind(this);
     }
 
     this.modFunctionGetCurrent = this.plain;
-    if ('mapGetCurrent' in config && config.mapGet) {
+    if ('mapGetCurrent' in config && config.mapGetCurrent) {
       this.modFunctionGetCurrent = function(value){return this.mapFunction(value, config.mapGetCurrent);}.bind(this);
     }
 
@@ -540,16 +540,16 @@ function GenericPLCAccessory(platform, config, accessoryNumber) {
       }.bind(this));
      }.bind(this);
 
-    if ('mapSetTarget' in config && config.mapSet) {
+    if ('mapSetTarget' in config && config.mapSetTarget) {
       this.modFunctionSet = function(value){return this.mapFunction(value, config.mapSetTarget);}.bind(this);
     }
 
-    if ('mapGetTarget' in config && config.mapGet) {
+    if ('mapGetTarget' in config && config.mapGetTarget) {
       this.modFunctionGet = function(value){return this.mapFunction(value, config.mapGetTarget);}.bind(this);
     }
 
     this.modFunctionGetCurrent = this.plain;
-    if ('mapGetCurrent' in config && config.mapGet) {
+    if ('mapGetCurrent' in config && config.mapGetCurrent) {
       this.modFunctionGetCurrent = function(value){return this.mapFunction(value, config.mapGetCurrent);}.bind(this);
     }
 
@@ -1455,14 +1455,14 @@ GenericPLCAccessory.prototype = {
       }
       if (this.config.get_CurrentHeatingCoolingState == offset)
       {
-        this.log.debug( "[" + this.name + "] Push CurrentHeatingCoolingState:" + value);
-        this.service.getCharacteristic(Characteristic.CurrentHeatingCoolingState).updateValue(value);
+        this.log.debug( "[" + this.name + "] Push CurrentHeatingCoolingState:" + String(this.modFunctionGetCurrent(parseInt(value))) + "<-" + String(value));
+        this.service.getCharacteristic(Characteristic.CurrentHeatingCoolingState).updateValue(this.modFunctionGetCurrent(parseInt(value)));
         rv = true;
       }
       if (this.config.get_TargetHeatingCoolingState == offset)
       {
-        this.log.debug( "[" + this.name + "] Push TargetHeatingCoolingState:" + value);
-        this.service.getCharacteristic(Characteristic.TargetHeatingCoolingState).updateValue(value);
+        this.log.debug( "[" + this.name + "] Push TargetHeatingCoolingState:" + String(this.modFunctionGet(parseInt(value))) + "<-" + String(value));
+        this.service.getCharacteristic(Characteristic.TargetHeatingCoolingState).updateValue(this.modFunctionGet(parseInt(value)));
         rv = true;
       }
       if (this.config.get_StatusTampered == offset)
@@ -1490,14 +1490,14 @@ GenericPLCAccessory.prototype = {
       }
       if (this.config.get_CurrentHumidifierDehumidifierState == offset)
       {
-        this.log.debug( "[" + this.name + "] Push CurrentHumidifierDehumidifierState:" + value);
-        this.service.getCharacteristic(Characteristic.CurrentHumidifierDehumidifierState).updateValue(value);
+        this.log.debug( "[" + this.name + "] Push CurrentHumidifierDehumidifierState:" + String(this.modFunctionGetCurrent(parseInt(value))) + "<-" + String(value));
+        this.service.getCharacteristic(Characteristic.CurrentHumidifierDehumidifierState).updateValue(this.modFunctionGetCurrent(parseInt(value)));
         rv = true;
       }
       if (this.config.get_TargetHumidifierDehumidifierState == offset)
-      {
-        this.log.debug( "[" + this.name + "] Push TargetHumidifierDehumidifierState:" + value);
-        this.service.getCharacteristic(Characteristic.TargetHumidifierDehumidifierState).updateValue(value);
+      {       
+        this.log.debug( "[" + this.name + "] Push TargetHumidifierDehumidifierState:" + String(this.modFunctionGet(parseInt(value))) + "<-" + String(value));
+        this.service.getCharacteristic(Characteristic.TargetHumidifierDehumidifierState).updateValue(this.modFunctionGet(parseInt(value)));
         rv = true;
       }
       if (this.config.get_CurrentRelativeHumidity == offset)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-plc",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "Homebridge plugin for Siemens Step7 and compatible PLCs. (https://github.com/homebridge)",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## [1.0.29] 2021-04-21

### Fixed
- `PLC_HumidifierDehumidifier` correct option `mapSetTarget`, `mapGetTarget`  and `mapGetCurrent`
- `PLC_Thermostat` correct option `mapSetTarget`, `mapGetTarget`  and `mapGetCurrent`

### Changed
- `PLC_SecuritySystem` introduce `mapSetTarget`, `mapGetTarget`  and `mapGetCurrent` this replaces `mapSet` and `mapGet`. (For backwards compatibility old options are still supported)