### PR TITLE
1.0.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
 # Changelog
+## [1.0.32] 2021-11-11
+
+With the latest update of the Homebridge UI docker container the the plugin does not start!
+
+Error: The module ... node_snap7.node was compile against a different Node.js version ... Please try re-compiling or re-installing ...
+
+During installation of this module snap7 is downloaded and compiled against the installed version of Node.js
+Therefore the issue is fixed for shure by deinstalling and installing the homebridge_plc plugin.
+
+### Changed
+- Updated dependant version of node-snap7 in hope that triggers an reinstall of node-snap7.
+
 ## [1.0.31] 2021-07-21
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-plc",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "Homebridge plugin for Siemens Step7 and compatible PLCs. (https://github.com/homebridge)",
   "license": "MIT",
   "keywords": [
@@ -27,7 +27,7 @@
   },
   "preferGlobal": true,
   "dependencies": {
-    "node-snap7": ">=1.0.4"
+    "node-snap7": ">=1.0.5"
   },
   "homepage": "https://github.com/Feilner/homebridge-plc#readme",
   "main": "index.js",


### PR DESCRIPTION
Updated dependant version of node-snap7 in hope that triggers an reinstall of node-snap7.

With the latest update of the Homebridge UI docker container the the plugin does not start!
Error: The module ... node_snap7.node was compile against a different Node.js version ...
During installation of this module snap7 is downloaded and compiled against the installed version of Node.js
Therefore the issue is fixed by deinstalling and installing the homebridge_plc plugin.
