### PR TITLE
Fix PLC_ContactSensor 'invert' field.

### DIFF
--- a/index.js
+++ b/index.js
@@ -880,7 +880,7 @@ function GenericPLCAccessory(platform, config, accessoryNumber) {
     this.service = new Service.ContactSensor(this.name);
     this.accessory.addService(this.service);
 
-    if ('invert' in config && config.invert) {
+    if ('invertContactSensorState' in config && config.invertContactSensorState) {
         this.modFunctionGet = this.invert_bit;
     }
 


### PR DESCRIPTION
PLC_ContactSensor should have renamed the obsolete field 'invert' to 'invertContactSensorState'.
This seems to have been forgotten during the upgrade to the new config schema.
Setting the 'invertContactSensorState' value did not have any effect.
This fix should correct the behavior.